### PR TITLE
Bcb5support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ projects/VS2010/TestCatch/_UpgradeReport_Files/
 projects/VS2010/TestCatch/TestCatch/TestCatch.vcxproj.filters
 projects/VisualStudio/TestCatch/UpgradeLog.XML
 UpgradeLog.XML
+/projects\CPPBuilder5/*.~cpp
+/single_include/*.~HPP
+/projects\CPPBuilder5/*.~cpp
+/projects\CPPBuilder5/*.~cpp
+/projects\CPPBuilder5/*.~cpp

--- a/include/internal/catch_commandline.hpp
+++ b/include/internal/catch_commandline.hpp
@@ -61,7 +61,7 @@ namespace Catch {
     
     class CommandParser {
     public:
-        CommandParser( int argc, char const * const * argv ) : m_argc( static_cast<std::size_t>( argc ) ), m_argv( argv ) {}
+        CommandParser( int argc, char* const argv[] ) : m_argc( static_cast<std::size_t>( argc ) ), m_argv( argv ) {}
 
         Command find( const std::string& arg1,  const std::string& arg2, const std::string& arg3 ) const {
             return find( arg1 ) + find( arg2 ) + find( arg3 );

--- a/include/internal/catch_console_colour_impl.hpp
+++ b/include/internal/catch_console_colour_impl.hpp
@@ -54,7 +54,7 @@ namespace Catch {
         }
         
         void set( TextColour::Colours colour ) {
-            WORD consoleColour = mapConsoleColour( colour );
+            WORD consoleColour = Catch::mapConsoleColour( colour );
             if( consoleColour > 0 )
                 SetConsoleTextAttribute( hStdout, consoleColour );
         }

--- a/include/internal/catch_interfaces_reporter.h
+++ b/include/internal/catch_interfaces_reporter.h
@@ -62,7 +62,7 @@ namespace Catch
         std::string::size_type start = str.find_first_not_of( "\n\r\t " );
         std::string::size_type end = str.find_last_not_of( "\n\r\t " );
         
-        return start != std::string::npos ? str.substr( start, 1+end-start ) : "";
+        return start != std::string::npos ? str.substr( start, 1+end-start ) : std::string();
     }
 }
 

--- a/include/internal/catch_resultinfo.hpp
+++ b/include/internal/catch_resultinfo.hpp
@@ -73,7 +73,7 @@ namespace Catch {
         }
         
         std::string getExpandedExpression() const {
-            return hasExpression() ? getExpandedExpressionInternal() : "";
+            return hasExpression() ? getExpandedExpressionInternal() : std::string();
         }
         
         std::string getMessage() const {

--- a/include/internal/catch_runner_impl.hpp
+++ b/include/internal/catch_runner_impl.hpp
@@ -227,7 +227,7 @@ namespace Catch {
         virtual std::string getCurrentTestName() const {
             return m_runningTest
                 ? m_runningTest->getTestCaseInfo().getName()
-                : "";
+                : std::string();
         }
 
         virtual const ResultInfo* getLastResult() const {

--- a/include/reporters/catch_reporter_basic.hpp
+++ b/include/reporters/catch_reporter_basic.hpp
@@ -71,7 +71,7 @@ namespace Catch {
             if( counts.passed )
                 m_config.stream() << counts.failed << " of " << counts.total() << " " << label << "s failed";
             else
-                m_config.stream() << ( counts.failed > 1 ? allPrefix : "" ) << pluralise( counts.failed, label ) << " failed";
+                m_config.stream() << ( counts.failed > 1 ? allPrefix : std::string() ) << pluralise( counts.failed, label ) << " failed";
         }
 
         void ReportCounts( const Totals& totals, const std::string& allPrefix = "All " ) {

--- a/projects/CPPBuilder5/.gitignore
+++ b/projects/CPPBuilder5/.gitignore
@@ -1,0 +1,5 @@
+/Tutorial1.exe
+/Tutorial1.obj
+/Tutorial1.tds
+/Tutorial1.~bpf
+/Tutorial1.~bpr

--- a/projects/CPPBuilder5/README.md
+++ b/projects/CPPBuilder5/README.md
@@ -1,0 +1,22 @@
+# Source directory for the CPPBuilder5 tutorial project
+
+## Instructions for the Borland free c++ compiler 
+
+* The download is still available at http://edn.embarcadero.com/article/20633/
+* run the installer - accept the default folder _C:\Borland\BCC55\Bin_ if you possibly can
+* in a command prompt cd to \<Catch checkout\>\projects\CPPBuilder5
+* _important_ you will probably *have* to run the environment setup script:
+  * bccenv.bat
+* run _make -f Tutorial1.mak_
+* Tutorial1.exe should be built in the current dir   
+  
+  
+## Instructions for c++ Builder
+* install c++ builder - I assume the default location on 32-bit Windows and _C:\CBuilder5\bin_ on 64-bit Windows
+* in a command prompt cd to <Catch checkout>\projects\CPPBuilder5
+* _important_ you will probably *have* to run the environment setup script:
+  * bcbenv.bat
+* building is simply run _make_
+* Tutorial1.exe should be built in the current dir   
+ 
+

--- a/projects/CPPBuilder5/Tutorial1.bpf
+++ b/projects/CPPBuilder5/Tutorial1.bpf
@@ -1,0 +1,5 @@
+USEUNIT("Tutorial1.cpp");
+//---------------------------------------------------------------------------
+This file is used by the project manager only and should be treated like the project file
+
+main

--- a/projects/CPPBuilder5/Tutorial1.bpr
+++ b/projects/CPPBuilder5/Tutorial1.bpr
@@ -23,7 +23,7 @@
     <RELEASELIBPATH value="$(BCB)\lib\release"/>
     <LINKER value="tlink32"/>
     <USERDEFINES value="_DEBUG;CATCH_PLATFORM_WINDOWS"/>
-    <SYSDEFINES value="NO_STRICT;_NO_VCL;_RTLDLL;USEPACKAGES"/>
+    <SYSDEFINES value="NO_STRICT;_NO_VCL"/>
     <MAINSOURCE value="Tutorial1.bpf"/>
     <INCLUDEPATH value="$(BCB)\include;$(BCB)\include\vcl;..\..\single_include"/>
     <LIBPATH value="$(BCB)\lib\obj;$(BCB)\lib"/>
@@ -38,9 +38,9 @@
     <LFLAGS value="-D&quot;&quot; -ap -Tpe -x -Gn -v"/>
   </OPTIONS>
   <LINKER>
-    <ALLOBJ value="c0x32.obj $(PACKAGES) $(OBJFILES)"/>
+    <ALLOBJ value="c0x32.obj $(OBJFILES)"/>
     <ALLRES value="$(RESFILES)"/>
-    <ALLLIB value="$(LIBFILES) $(LIBRARIES) import32.lib cw32i.lib"/>
+    <ALLLIB value="$(LIBFILES) $(LIBRARIES) import32.lib cw32.lib"/>
   </LINKER>
   <IDEOPTIONS>
 [Version Info]

--- a/projects/CPPBuilder5/Tutorial1.bpr
+++ b/projects/CPPBuilder5/Tutorial1.bpr
@@ -1,0 +1,116 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<!-- C++Builder XML Project -->
+<PROJECT>
+  <MACROS>
+    <VERSION value="BCB.05.03"/>
+    <PROJECT value="Tutorial1.exe"/>
+    <OBJFILES value="Tutorial1.obj"/>
+    <RESFILES value=""/>
+    <DEFFILE value=""/>
+    <RESDEPEN value="$(RESFILES)"/>
+    <LIBFILES value=""/>
+    <LIBRARIES value=""/>
+    <SPARELIBS value=""/>
+    <PACKAGES value="Vcl50.bpi Vclx50.bpi bcbsmp50.bpi Qrpt50.bpi Vcldb50.bpi Vclbde50.bpi 
+      ibsmp50.bpi vcldbx50.bpi TeeUI50.bpi TeeDB50.bpi Tee50.bpi TeeQR50.bpi 
+      VCLIB50.bpi bcbie50.bpi vclie50.bpi Inetdb50.bpi Inet50.bpi NMFast50.bpi 
+      dclocx50.bpi bcb2kaxserver50.bpi"/>
+    <PATHCPP value=".;"/>
+    <PATHPAS value=".;"/>
+    <PATHRC value=".;"/>
+    <PATHASM value=".;"/>
+    <DEBUGLIBPATH value="$(BCB)\lib\debug"/>
+    <RELEASELIBPATH value="$(BCB)\lib\release"/>
+    <LINKER value="tlink32"/>
+    <USERDEFINES value="_DEBUG;CATCH_PLATFORM_WINDOWS"/>
+    <SYSDEFINES value="NO_STRICT;_NO_VCL;_RTLDLL;USEPACKAGES"/>
+    <MAINSOURCE value="Tutorial1.bpf"/>
+    <INCLUDEPATH value="$(BCB)\include;$(BCB)\include\vcl;..\..\single_include"/>
+    <LIBPATH value="$(BCB)\lib\obj;$(BCB)\lib"/>
+    <WARNINGS value="-w-par"/>
+  </MACROS>
+  <OPTIONS>
+    <CFLAG1 value="-Od -H=$(BCB)\lib\vcl50.csm -Hc -Vx -Ve -X- -r- -a8 -b- -k -y -v -vi- -tWC 
+      -tWM- -c"/>
+    <PFLAGS value="-$YD -$W -$O- -v -JPHNE -M"/>
+    <RFLAGS value=""/>
+    <AFLAGS value="/mx /w2 /zd"/>
+    <LFLAGS value="-D&quot;&quot; -ap -Tpe -x -Gn -v"/>
+  </OPTIONS>
+  <LINKER>
+    <ALLOBJ value="c0x32.obj $(PACKAGES) $(OBJFILES)"/>
+    <ALLRES value="$(RESFILES)"/>
+    <ALLLIB value="$(LIBFILES) $(LIBRARIES) import32.lib cw32i.lib"/>
+  </LINKER>
+  <IDEOPTIONS>
+[Version Info]
+IncludeVerInfo=0
+AutoIncBuild=0
+MajorVer=1
+MinorVer=0
+Release=0
+Build=0
+Debug=0
+PreRelease=0
+Special=0
+Private=0
+DLL=0
+Locale=2057
+CodePage=1252
+
+[Version Info Keys]
+CompanyName=
+FileDescription=
+FileVersion=1.0.0.0
+InternalName=
+LegalCopyright=
+LegalTrademarks=
+OriginalFilename=
+ProductName=
+ProductVersion=1.0.0.0
+Comments=
+
+[Excluded Packages]
+$(BCB)\Projects\Bpl\ThemeManagerC5D.bpl=Soft Gems Theme Manager
+
+[HistoryLists\hlIncludePath]
+Count=3
+Item0=$(BCB)\include;$(BCB)\include\vcl;..\..\single_include
+Item1=..\..\..\..\CatchSimpleTest;$(BCB)\include;$(BCB)\include\vcl
+Item2=$(BCB)\include;$(BCB)\include\vcl
+
+[HistoryLists\hlLibraryPath]
+Count=2
+Item0=$(BCB)\lib\obj;$(BCB)\lib
+Item1=..\..\..\..\CatchSimpleTest;$(BCB)\lib\obj;$(BCB)\lib
+
+[HistoryLists\hlDebugSourcePath]
+Count=1
+Item0=$(BCB)\source\vcl
+
+[HistoryLists\hlConditionals]
+Count=2
+Item0=_DEBUG;CATCH_PLATFORM_WINDOWS
+Item1=_DEBUG
+
+[Debugging]
+DebugSourceDirs=$(BCB)\source\vcl
+
+[Parameters]
+RunParams=
+HostApplication=
+RemoteHost=
+RemotePath=
+RemoteDebug=0
+
+[Compiler]
+ShowInfoMsgs=0
+LinkDebugVcl=0
+LinkCGLIB=0
+
+[Language]
+ActiveLang=
+ProjectLang=
+RootDir=
+  </IDEOPTIONS>
+</PROJECT>

--- a/projects/CPPBuilder5/Tutorial1.cpp
+++ b/projects/CPPBuilder5/Tutorial1.cpp
@@ -1,0 +1,15 @@
+  #define CATCH_CONFIG_MAIN  // This tell CATCH to provide a main() - only do this in one cpp file
+  #include "catch.hpp"
+
+  unsigned int Factorial( unsigned int number ) {
+      return number <= 1 ? number : Factorial(number-1)*number;
+  }
+
+  TEST_CASE( "example/factorial", "The Factorial function returns the factorial of the number passed in" ) {
+      REQUIRE( Factorial(0) == (unsigned) 1 );
+      REQUIRE( Factorial(1) == (unsigned) 1 );         
+      REQUIRE( Factorial(2) == (unsigned) 2 );
+      REQUIRE( Factorial(3) == (unsigned) 6 );
+      REQUIRE( Factorial(10) == (unsigned) 3628800 );
+
+  } 

--- a/projects/CPPBuilder5/Tutorial1.mak
+++ b/projects/CPPBuilder5/Tutorial1.mak
@@ -1,0 +1,187 @@
+# ---------------------------------------------------------------------------
+!if !$d(BCB)
+BCB = $(MAKEDIR)\..
+!endif
+
+# ---------------------------------------------------------------------------
+# IDE SECTION
+# ---------------------------------------------------------------------------
+# The following section of the project makefile is managed by the BCB IDE.
+# It is recommended to use the IDE to change any of the values in this
+# section.
+# ---------------------------------------------------------------------------
+
+VERSION = BCB.05.03
+# ---------------------------------------------------------------------------
+PROJECT = Tutorial1.exe
+OBJFILES = Tutorial1.obj
+RESFILES = 
+MAINSOURCE = Tutorial1.bpf
+RESDEPEN = $(RESFILES)
+LIBFILES = 
+IDLFILES = 
+IDLGENFILES = 
+LIBRARIES = 
+PACKAGES = Vcl50.bpi Vclx50.bpi bcbsmp50.bpi Qrpt50.bpi Vcldb50.bpi Vclbde50.bpi \
+    ibsmp50.bpi vcldbx50.bpi TeeUI50.bpi TeeDB50.bpi Tee50.bpi TeeQR50.bpi \
+    VCLIB50.bpi bcbie50.bpi vclie50.bpi Inetdb50.bpi Inet50.bpi NMFast50.bpi \
+    dclocx50.bpi bcb2kaxserver50.bpi
+SPARELIBS = 
+DEFFILE = 
+# ---------------------------------------------------------------------------
+PATHCPP = .;
+PATHASM = .;
+PATHPAS = .;
+PATHRC = .;
+DEBUGLIBPATH = $(BCB)\lib\debug
+RELEASELIBPATH = $(BCB)\lib\release
+USERDEFINES = _DEBUG;CATCH_PLATFORM_WINDOWS
+SYSDEFINES = NO_STRICT;_NO_VCL;_RTLDLL;USEPACKAGES
+INCLUDEPATH = $(BCB)\include;$(BCB)\include\vcl;..\..\single_include
+LIBPATH = $(BCB)\lib\obj;$(BCB)\lib
+WARNINGS= -w-par
+# ---------------------------------------------------------------------------
+CFLAG1 = -Od -H=$(BCB)\lib\vcl50.csm -Hc -Vx -Ve -X- -r- -a8 -b- -k -y -v -vi- -tWC \
+    -tWM- -c
+IDLCFLAGS = 
+PFLAGS = -$YD -$W -$O- -v -JPHNE -M
+RFLAGS = 
+AFLAGS = /mx /w2 /zd
+LFLAGS = -D"" -ap -Tpe -x -Gn -v
+# ---------------------------------------------------------------------------
+ALLOBJ = c0x32.obj $(PACKAGES) $(OBJFILES)
+ALLRES = $(RESFILES)
+ALLLIB = $(LIBFILES) $(LIBRARIES) import32.lib cw32i.lib
+# ---------------------------------------------------------------------------
+!ifdef IDEOPTIONS
+
+[Version Info]
+IncludeVerInfo=0
+AutoIncBuild=0
+MajorVer=1
+MinorVer=0
+Release=0
+Build=0
+Debug=0
+PreRelease=0
+Special=0
+Private=0
+DLL=0
+
+[Version Info Keys]
+CompanyName=
+FileDescription=
+FileVersion=1.0.0.0
+InternalName=
+LegalCopyright=
+LegalTrademarks=
+OriginalFilename=
+ProductName=
+ProductVersion=1.0.0.0
+Comments=
+
+[Debugging]
+DebugSourceDirs=$(BCB)\source\vcl
+
+!endif
+
+
+
+
+
+# ---------------------------------------------------------------------------
+# MAKE SECTION
+# ---------------------------------------------------------------------------
+# This section of the project file is not used by the BCB IDE.  It is for
+# the benefit of building from the command-line using the MAKE utility.
+# ---------------------------------------------------------------------------
+
+.autodepend
+# ---------------------------------------------------------------------------
+!if "$(USERDEFINES)" != ""
+AUSERDEFINES = -d$(USERDEFINES:;= -d)
+!else
+AUSERDEFINES =
+!endif
+
+!if !$d(BCC32)
+BCC32 = bcc32
+!endif
+
+!if !$d(CPP32)
+CPP32 = cpp32
+!endif
+
+!if !$d(DCC32)
+DCC32 = dcc32
+!endif
+
+!if !$d(TASM32)
+TASM32 = tasm32
+!endif
+
+!if !$d(LINKER)
+LINKER = ilink32
+!endif
+
+!if !$d(BRCC32)
+BRCC32 = brcc32
+!endif
+
+
+# ---------------------------------------------------------------------------
+!if $d(PATHCPP)
+.PATH.CPP = $(PATHCPP)
+.PATH.C   = $(PATHCPP)
+!endif
+
+!if $d(PATHPAS)
+.PATH.PAS = $(PATHPAS)
+!endif
+
+!if $d(PATHASM)
+.PATH.ASM = $(PATHASM)
+!endif
+
+!if $d(PATHRC)
+.PATH.RC  = $(PATHRC)
+!endif
+# ---------------------------------------------------------------------------
+$(PROJECT): $(IDLGENFILES) $(OBJFILES) $(RESDEPEN) $(DEFFILE)
+    $(BCB)\BIN\$(LINKER) @&&!
+    $(LFLAGS) -L$(LIBPATH) +
+    $(ALLOBJ), +
+    $(PROJECT),, +
+    $(ALLLIB), +
+    $(DEFFILE), +
+    $(ALLRES)
+!
+# ---------------------------------------------------------------------------
+.pas.hpp:
+    $(BCB)\BIN\$(DCC32) $(PFLAGS) -U$(INCLUDEPATH) -D$(USERDEFINES);$(SYSDEFINES) -O$(INCLUDEPATH) --BCB {$< }
+
+.pas.obj:
+    $(BCB)\BIN\$(DCC32) $(PFLAGS) -U$(INCLUDEPATH) -D$(USERDEFINES);$(SYSDEFINES) -O$(INCLUDEPATH) --BCB {$< }
+
+.cpp.obj:
+    $(BCB)\BIN\$(BCC32) $(CFLAG1) $(WARNINGS) -I$(INCLUDEPATH) -D$(USERDEFINES);$(SYSDEFINES) -n$(@D) {$< }
+
+.c.obj:
+    $(BCB)\BIN\$(BCC32) $(CFLAG1) $(WARNINGS) -I$(INCLUDEPATH) -D$(USERDEFINES);$(SYSDEFINES) -n$(@D) {$< }
+
+.c.i:
+    $(BCB)\BIN\$(CPP32) $(CFLAG1) $(WARNINGS) -I$(INCLUDEPATH) -D$(USERDEFINES);$(SYSDEFINES) -n. {$< }
+
+.cpp.i:
+    $(BCB)\BIN\$(CPP32) $(CFLAG1) $(WARNINGS) -I$(INCLUDEPATH) -D$(USERDEFINES);$(SYSDEFINES) -n. {$< }
+
+.asm.obj:
+    $(BCB)\BIN\$(TASM32) $(AFLAGS) -i$(INCLUDEPATH:;= -i) $(AUSERDEFINES) -d$(SYSDEFINES:;= -d) $<, $@
+
+.rc.res:
+    $(BCB)\BIN\$(BRCC32) $(RFLAGS) -I$(INCLUDEPATH) -D$(USERDEFINES);$(SYSDEFINES) -fo$@ $<
+# ---------------------------------------------------------------------------
+
+
+
+

--- a/projects/CPPBuilder5/Tutorial1.mak
+++ b/projects/CPPBuilder5/Tutorial1.mak
@@ -36,7 +36,7 @@ PATHRC = .;
 DEBUGLIBPATH = $(BCB)\lib\debug
 RELEASELIBPATH = $(BCB)\lib\release
 USERDEFINES = _DEBUG;CATCH_PLATFORM_WINDOWS
-SYSDEFINES = NO_STRICT;_NO_VCL;_RTLDLL;USEPACKAGES
+SYSDEFINES = NO_STRICT;_NO_VCL
 INCLUDEPATH = $(BCB)\include;$(BCB)\include\vcl;..\..\single_include
 LIBPATH = $(BCB)\lib\obj;$(BCB)\lib
 WARNINGS= -w-par
@@ -49,9 +49,9 @@ RFLAGS =
 AFLAGS = /mx /w2 /zd
 LFLAGS = -D"" -ap -Tpe -x -Gn -v
 # ---------------------------------------------------------------------------
-ALLOBJ = c0x32.obj $(PACKAGES) $(OBJFILES)
+ALLOBJ = c0x32.obj $(OBJFILES)
 ALLRES = $(RESFILES)
-ALLLIB = $(LIBFILES) $(LIBRARIES) import32.lib cw32i.lib
+ALLLIB = $(LIBFILES) $(LIBRARIES) import32.lib cw32.lib
 # ---------------------------------------------------------------------------
 !ifdef IDEOPTIONS
 

--- a/projects/CPPBuilder5/bcbenv.bat
+++ b/projects/CPPBuilder5/bcbenv.bat
@@ -1,0 +1,3 @@
+@echo off
+IF "%ProgramFiles(x86)%"=="" SET PATH="C:\PROGRA~1\Borland\CBUILD~1\bin";"C:\Program Files\Git\cmd";"c:\Program Files\doxygen\bin";C:\Windows\System32 & exit /b
+SET PATH=C:\CBuilder5\bin;"C:\Program Files (x86)\Git\cmd";"c:\Program Files\doxygen\bin";C:\Windows\System32

--- a/projects/CPPBuilder5/bccenv.bat
+++ b/projects/CPPBuilder5/bccenv.bat
@@ -1,0 +1,3 @@
+@echo off
+IF "%ProgramFiles(x86)%"=="" SET PATH="C:\Borland\BCC55\Bin";"C:\Program Files\Git\cmd";"c:\Program Files\doxygen\bin";C:\Windows\System32 & exit /b
+SET PATH=C:\Borland\BCC55\Bin;"C:\Program Files (x86)\Git\cmd";"c:\Program Files\doxygen\bin";C:\Windows\System32

--- a/projects/CPPBuilder5/makefile
+++ b/projects/CPPBuilder5/makefile
@@ -1,0 +1,50 @@
+ROOT = $(MAKEDIR)\..
+BRCC = $(ROOT)\bin\brcc32.exe 
+
+.silent
+default: clean all
+
+clean: 
+	echo ========== cleaning object files ======
+	-@DEL /F /Q /S *.obj *.tds *.exe 1>nul
+	
+		
+# this override of the default implicit rule is a hack for not getting a ".bpr.exe" rule working correctly
+# to override the default .cpp.exe rule
+# currently relying upon BCB convention of a main cpp file named for the project listing project files
+.cpp.exe: 
+	echo ========== build for $@ ======
+	bpr2mak -q $&.bpr
+	make -a -f $&.mak
+
+Tutorial1.exe: 
+
+TARGETS= Tutorial1.exe 
+
+all: $(TARGETS) 
+
+help:
+	@echo targets built by this makefile: $(TARGETS)
+	@echo.
+	@echo help - shows this output
+	@echo all - builds all targets
+	@echo clean - cleans all targets
+	@echo tests - performs some tests on targets
+	@echo default - clean all
+	
+	
+pre-tests: 
+	echo ========== running tests ======
+
+post-tests: 
+	echo ========== completed tests ======
+
+tests: Tutorial1.exe pre-tests unit-tests post-tests
+		
+	
+unit-tests: Tutorial1.exe
+	-Tutorial1.exe
+
+
+
+	

--- a/single_include/catch.hpp
+++ b/single_include/catch.hpp
@@ -1,5 +1,5 @@
 /*
- *  Generated: 2012-07-05 18:47:13.729198
+ *  Generated: 2012-07-19 00:07:37.689000
  *  ----------------------------------------------------------
  *  This file has been merged from multiple headers. Please don't edit it directly
  *  Copyright (c) 2012 Two Blue Cubes Ltd. All rights reserved.
@@ -318,7 +318,7 @@ namespace Catch
         std::string::size_type start = str.find_first_not_of( "\n\r\t " );
         std::string::size_type end = str.find_last_not_of( "\n\r\t " );
 
-        return start != std::string::npos ? str.substr( start, 1+end-start ) : "";
+        return start != std::string::npos ? str.substr( start, 1+end-start ) : std::string();
     }
 }
 
@@ -759,7 +759,7 @@ namespace Catch {
         }
 
         std::string getExpandedExpression() const {
-            return hasExpression() ? getExpandedExpressionInternal() : "";
+            return hasExpression() ? getExpandedExpressionInternal() : std::string();
         }
 
         std::string getMessage() const {
@@ -2212,9 +2212,6 @@ namespace Catch {
     inline std::string toString( NSString* const& nsstring ) {
         return std::string( "@\"" ) + [nsstring UTF8String] + "\"";
     }
-    inline std::string toString( NSObject* const& nsObject ) {
-        return toString( [nsObject description] );
-    }
 
     namespace Matchers {
         namespace Impl {
@@ -2986,7 +2983,7 @@ namespace Catch {
         virtual std::string getCurrentTestName() const {
             return m_runningTest
                 ? m_runningTest->getTestCaseInfo().getName()
-                : "";
+                : std::string();
         }
 
         virtual const ResultInfo* getLastResult() const {
@@ -3210,7 +3207,7 @@ namespace Catch {
         }
 
         void set( TextColour::Colours colour ) {
-            WORD consoleColour = mapConsoleColour( colour );
+            WORD consoleColour = Catch::mapConsoleColour( colour );
             if( consoleColour > 0 )
                 SetConsoleTextAttribute( hStdout, consoleColour );
         }
@@ -3551,7 +3548,7 @@ namespace Catch {
 
     class CommandParser {
     public:
-        CommandParser( int argc, char const * const * argv ) : m_argc( static_cast<std::size_t>( argc ) ), m_argv( argv ) {}
+        CommandParser( int argc, char* const argv[] ) : m_argc( static_cast<std::size_t>( argc ) ), m_argv( argv ) {}
 
         Command find( const std::string& arg1,  const std::string& arg2, const std::string& arg3 ) const {
             return find( arg1 ) + find( arg2 ) + find( arg3 );
@@ -3799,7 +3796,7 @@ namespace Catch {
             if( counts.passed )
                 m_config.stream() << counts.failed << " of " << counts.total() << " " << label << "s failed";
             else
-                m_config.stream() << ( counts.failed > 1 ? allPrefix : "" ) << pluralise( counts.failed, label ) << " failed";
+                m_config.stream() << ( counts.failed > 1 ? allPrefix : std::string() ) << pluralise( counts.failed, label ) << " failed";
         }
 
         void ReportCounts( const Totals& totals, const std::string& allPrefix = "All " ) {


### PR DESCRIPTION
Hi Phil, as discussed, here is the sum total of the changes for BCB5 (and the free 5.5 compiler).

My first pull request, so here goes...

Above all: please note the breaking change in

include/internal/catch_commandline.hpp L 64

this breaks VS 2010 at very least, but otherwise BCB5 is broken, as best I can determine.

I presume omit this line if you do want to accept the patch, but I've left it in for our reference.  

The remaining controversy is from BCB getting caught out in resolving mapConsoleColour

include/internal/catch_console_colour_impl.hpp L 57

Finally, there's a working BCB project with a command line build available via a Borland make compatible makefile.

Kind regards, Patrick
