### PR TITLE
Avoid GCC warnings (-Wold-style-casts and -Wshadow)

### DIFF
--- a/include/internal/catch_commandline.hpp
+++ b/include/internal/catch_commandline.hpp
@@ -24,14 +24,14 @@ namespace Catch {
 
     inline void addWarning( ConfigData& config, std::string const& _warning ) {
         if( _warning == "NoAssertions" )
-            config.warnings = (ConfigData::WarnAbout::What)( config.warnings | ConfigData::WarnAbout::NoAssertions );
+            config.warnings = static_cast<ConfigData::WarnAbout::What>( config.warnings | ConfigData::WarnAbout::NoAssertions );
         else
             throw std::runtime_error( "Unrecognised warning: '" + _warning + "'" );
 
     }
     inline void setVerbosity( ConfigData& config, int level ) {
         // !TBD: accept strings?
-        config.verbosity = (ConfigData::Verbosity::Level)level;
+        config.verbosity = static_cast<ConfigData::Verbosity::Level>(level);
     }
 
     inline Clara::CommandLine<ConfigData> makeCommandLineParser() {

--- a/include/internal/catch_config.hpp
+++ b/include/internal/catch_config.hpp
@@ -95,15 +95,15 @@ namespace Catch {
                         groupName += " ";
                     groupName += data.testsOrTags[i];
                 }
-                TestCaseFilters filters( groupName );
+                TestCaseFilters filterSet( groupName );
                 for( std::size_t i = 0; i < data.testsOrTags.size(); ++i ) {
                     std::string filter = data.testsOrTags[i];
                     if( startsWith( filter, "[" ) || startsWith( filter, "~[" ) )
-                        filters.addTags( filter );
+                        filterSet.addTags( filter );
                     else
-                        filters.addFilter( TestCaseFilter( filter ) );
+                        filterSet.addFilter( TestCaseFilter( filter ) );
                 }
-                m_filterSets.push_back( filters );
+                m_filterSets.push_back( filterSet );
             }
         }
 
@@ -137,18 +137,18 @@ namespace Catch {
         }
 
         void useStream( std::string const& streamName ) {
-            Stream stream = createStream( streamName );
-            setStreamBuf( stream.streamBuf );
+            Stream tempStream = createStream( streamName );
+            setStreamBuf( tempStream.streamBuf );
             m_stream.release();
-            m_stream = stream;
+            m_stream = tempStream;
         }
 
         std::string getReporterName() const { return m_data.reporterName; }
 
         void addTestSpec( std::string const& testSpec ) {
-            TestCaseFilters filters( testSpec );
-            filters.addFilter( TestCaseFilter( testSpec ) );
-            m_filterSets.push_back( filters );
+            TestCaseFilters filterSet( testSpec );
+            filterSet.addFilter( TestCaseFilter( testSpec ) );
+            m_filterSets.push_back( filterSet );
         }
 
         int abortAfter() const {

--- a/include/internal/catch_runner_impl.hpp
+++ b/include/internal/catch_runner_impl.hpp
@@ -56,11 +56,11 @@ namespace Catch {
 
     public:
 
-        explicit RunContext( Ptr<IConfig const> const& config, Ptr<IStreamingReporter> const& reporter )
-        :   m_runInfo( config->name() ),
+        explicit RunContext( Ptr<IConfig const> const& _config, Ptr<IStreamingReporter> const& reporter )
+        :   m_runInfo( _config->name() ),
             m_context( getCurrentMutableContext() ),
             m_activeTestCase( NULL ),
-            m_config( config ),
+            m_config( _config ),
             m_reporter( reporter ),
             m_prevRunner( &m_context.getRunner() ),
             m_prevResultCapture( &m_context.getResultCapture() ),
@@ -256,9 +256,9 @@ namespace Catch {
             if( !m_lastResult.isOk() ) {
                 action = ResultAction::Failed;
                 if( shouldDebugBreak() )
-                    action = (ResultAction::Value)( action | ResultAction::Debug );
+                    action = static_cast<ResultAction::Value>( action | ResultAction::Debug );
                 if( aborting() )
-                    action = (ResultAction::Value)( action | ResultAction::Abort );
+                    action = static_cast<ResultAction::Value>( action | ResultAction::Abort );
             }
             return action;
         }

--- a/include/internal/catch_tags.hpp
+++ b/include/internal/catch_tags.hpp
@@ -88,9 +88,9 @@ namespace Catch {
         :   m_isNegated( false )
         {}
 
-        Tag( std::string const& name, bool isNegated )
+        Tag( std::string const& name, bool _isNegated )
         :   m_name( name ),
-            m_isNegated( isNegated )
+            m_isNegated( _isNegated )
         {}
 
         std::string getName() const {

--- a/include/internal/catch_test_spec.h
+++ b/include/internal/catch_test_spec.h
@@ -53,11 +53,11 @@ namespace Catch {
 
             if( startsWith( m_stringToMatch, "*" ) ) {
                 m_stringToMatch = m_stringToMatch.substr( 1 );
-                m_wildcardPosition = (WildcardPosition)( m_wildcardPosition | WildcardAtStart );
+                m_wildcardPosition = static_cast<WildcardPosition>( m_wildcardPosition | WildcardAtStart );
             }
             if( endsWith( m_stringToMatch, "*" ) ) {
                 m_stringToMatch = m_stringToMatch.substr( 0, m_stringToMatch.size()-1 );
-                m_wildcardPosition = (WildcardPosition)( m_wildcardPosition | WildcardAtEnd );
+                m_wildcardPosition = static_cast<WildcardPosition>( m_wildcardPosition | WildcardAtEnd );
             }
         }
 

--- a/include/internal/clara.h
+++ b/include/internal/clara.h
@@ -347,12 +347,12 @@ namespace Clara {
                 m_arg.description = description;
                 return *this;
             }
-            ArgBinder& argName( std::string const& argName ) {
-                m_arg.argName = argName;
+            ArgBinder& argName( std::string const& _argName ) {
+                m_arg.argName = _argName;
                 return *this;
             }
-            ArgBinder& position( int position ) {
-                m_arg.position = position;
+            ArgBinder& position( int _position ) {
+                m_arg.position = _position;
                 return *this;
             }
         private:
@@ -393,20 +393,20 @@ namespace Clara {
                 maxWidth = (std::max)( maxWidth, it->commands().size() );
 
             for( it = itBegin; it != itEnd; ++it ) {
-                Catch::Text usage( it->commands(), Catch::TextAttributes()
+                Catch::Text usageString( it->commands(), Catch::TextAttributes()
                                                         .setWidth( maxWidth+indent )
                                                         .setIndent( indent ) );
                 // !TBD handle longer usage strings
-                Catch::Text desc( it->description, Catch::TextAttributes()
+                Catch::Text descString( it->description, Catch::TextAttributes()
                                                         .setWidth( width - maxWidth -3 ) );
 
-                for( std::size_t i = 0; i < (std::max)( usage.size(), desc.size() ); ++i ) {
-                    std::string usageCol = i < usage.size() ? usage[i] : "";
+                for( std::size_t i = 0; i < (std::max)( usageString.size(), descString.size() ); ++i ) {
+                    std::string usageCol = i < usageString.size() ? usageString[i] : "";
                     os << usageCol;
 
-                    if( i < desc.size() && !desc[i].empty() )
+                    if( i < descString.size() && !descString[i].empty() )
                         os  << std::string( indent + 2 + maxWidth - usageCol.size(), ' ' )
-                            << desc[i];
+                            << descString[i];
                     os << "\n";
                 }
             }


### PR DESCRIPTION
I worked around a few warnings which my GCC (4.7.2) spat out.

See also issue #83.