### PR TITLE
re-added signal handling to the latest Catch (fetched from latest upstream) (re-adding #160)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![catch logo](catch-logo-small.png)
 
-*v1.0 build 19 (master branch)*
+*v1.0 build 23 (master branch)*
 
 Build status (on Travis CI) [![Build Status](https://travis-ci.org/philsquared/Catch.png)](https://travis-ci.org/philsquared/Catch)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![catch logo](catch-logo-small.png)
 
-*v1.0 build 24 (master branch)*
+*v1.0 build 25 (master branch)*
 
 Build status (on Travis CI) [![Build Status](https://travis-ci.org/philsquared/Catch.png)](https://travis-ci.org/philsquared/Catch)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![catch logo](catch-logo-small.png)
 
-*v1.0 build 23 (master branch)*
+*v1.0 build 24 (master branch)*
 
 Build status (on Travis CI) [![Build Status](https://travis-ci.org/philsquared/Catch.png)](https://travis-ci.org/philsquared/Catch)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![catch logo](catch-logo-small.png)
 
-*v1.0 build 25 (master branch)*
+*v1.0 build 26 (master branch)*
 
 Build status (on Travis CI) [![Build Status](https://travis-ci.org/philsquared/Catch.png)](https://travis-ci.org/philsquared/Catch)
 

--- a/include/internal/catch_default_main.hpp
+++ b/include/internal/catch_default_main.hpp
@@ -10,7 +10,16 @@
 
 #ifndef __OBJC__
 
-#if !defined(DO_NOT_USE_SIGNALS)
+#ifdef TIMEOUT_FOR_ALL_TESTS_IN_SECONDS
+#ifdef __GNUC__
+#define USING_TIMEOUTS
+#else /*!__GNUC__ = for MSVC pthreads-win32 is needed (
+      unless this library will go to C++11 and use std::thread, in which case below could be updated accordingly)*/
+#pragma message ("\nWARNING: Specified TIMEOUT_FOR_ALL_TESTS_IN_SECONDS, but it's only supported with GCC compilers..\n")
+#endif /*__GNUC__*/
+#endif /*TIMEOUT_FOR_ALL_TESTS_IN_SECONDS*/
+
+#if defined(USING_TIMEOUTS) || !defined(DO_NOT_USE_SIGNALS)
 #include <sstream>
 #include <iostream>
 void add_test_info(std::stringstream& s) {
@@ -28,6 +37,38 @@ void add_test_info(std::stringstream& s) {
     Catch::cleanUp();
 }
 #endif
+
+#ifdef USING_TIMEOUTS
+#include <pthread.h>
+#ifdef CATCH_PLATFORM_WINDOWS
+#define SLEEP(x) Sleep(x)
+#else
+#include <unistd.h>
+#define SLEEP(x) sleep(x/1000)
+#endif
+
+void* timeout_thread_fcn(void* arg) {
+    pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+    pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
+    unsigned int elapsed_s = 0;
+    volatile bool& exit_timeout_thread = *static_cast<bool*>(arg);
+    while(!exit_timeout_thread) {
+        SLEEP(1000);
+        elapsed_s++;
+        if (elapsed_s == TIMEOUT_FOR_ALL_TESTS_IN_SECONDS)
+        {
+           std::stringstream info;
+           info << "\n\n=================\n\n";
+           info << "Test execution timed out";
+           info << " (timeout was: " <<  TIMEOUT_FOR_ALL_TESTS_IN_SECONDS << " seconds)\n";
+           add_test_info(info);
+           std::cerr << info.str();
+           exit(-1);
+        }
+    }
+    return NULL;
+}
+#endif /*!TIMEOUT_FOR_ALL_TESTS_IN_SECONDS*/
 
 #ifndef DO_NOT_USE_SIGNALS
 static bool testing_finished = false;
@@ -66,16 +107,15 @@ void handle_signal(int sig) {
     default:
         break;
     }
-
     add_test_info(s);
     std::cout << s.str();
-
     exit(-sig);
 }
 #endif /*!DO_NOT_USE_SIGNALS*/
 
 // Standard C/C++ main entry point
 int main (int argc, char * const argv[]) {
+    int ret = 0;
 #ifndef DO_NOT_USE_SIGNALS
     testing_finished = false;
     signal(SIGSEGV, handle_signal);
@@ -86,25 +126,25 @@ int main (int argc, char * const argv[]) {
     signal(SIGFPE, handle_signal);
 #endif /*!DO_NOT_USE_SIGNALS*/
 
-    return Catch::Session().run( argc, argv );
-}
+#ifdef USING_TIMEOUTS
+    pthread_t timeout_thread;
+    volatile bool exit_timeout_thread = false;
+    ret = pthread_create(&timeout_thread,
+                         NULL,
+                         timeout_thread_fcn,
+                         (void*)&exit_timeout_thread);
+    if (ret) {
+        std::cerr << "Catch failed to start timeout thread (pthread_create failed with %d" << ret << ")\n";
+        return ret;
+        }
+#endif /*!USING_TIMEOUTS*/
 
-#else // __OBJC__
+    ret = Catch::Session().run( argc, argv );
 
-// Objective-C entry point
-int main (int argc, char * const argv[]) {
-#if !CATCH_ARC_ENABLED
-    NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
-#endif
-
-    Catch::registerTestMethods();
-    int result = Catch::Session().run( argc, (char* const*)argv );
-
-#if !CATCH_ARC_ENABLED
-    [pool drain];
-#endif
-
-    return result;
+#ifndef DO_NOT_USE_SIGNALS
+    testing_finished = true;
+#endif /*!DO_NOT_USE_SIGNALS*/
+    return ret;
 }
 
 #endif // __OBJC__

--- a/include/internal/catch_default_main.hpp
+++ b/include/internal/catch_default_main.hpp
@@ -10,8 +10,82 @@
 
 #ifndef __OBJC__
 
+#if !defined(DO_NOT_USE_SIGNALS)
+#include <sstream>
+#include <iostream>
+void add_test_info(std::stringstream& s) {
+    // add info about current test
+    Catch::IContext& context = Catch::getCurrentContext();
+    Catch::IResultCapture& result = context.getResultCapture();
+    const Catch::AssertionResult* ar = result.getLastResult();
+    if(ar) {
+        Catch::SourceLineInfo src = ar->getSourceInfo();
+        s << "\n\nwhile executing test: \"" << result.getCurrentTestName() << "\"\n";
+        s << "\n(last successful check was: \"" << ar->getExpression() << "\"\n";
+        s << " in: " << src.file << ", ";
+        s << "line: " << static_cast<int>(src.line) << ")\n\n";
+    }
+    Catch::cleanUp();
+}
+#endif
+
+#ifndef DO_NOT_USE_SIGNALS
+static bool testing_finished = false;
+#include <signal.h>
+
+// handler for signals
+void handle_signal(int sig) {
+    std::stringstream s;
+    s << "\n\n=================\n\n";
+    if(testing_finished)
+    {
+        std::cerr << s.str() << "received signal " << std::dec << sig;
+        std::cerr << " after testing was finished\n";
+        exit(0);
+    }
+
+    switch (sig) {
+    case SIGINT:
+        s << "Interactive attention";
+        break;
+    case SIGILL:
+        s << "Illegal instruction";
+        break;
+    case SIGFPE:
+        s << "Floating point error";
+        break;
+    case SIGSEGV:
+        s << "Segmentation violation";
+        break;
+    case SIGTERM:
+        s << "Termination request";
+        break;
+    case SIGABRT:
+        s << "Abnormal termination (abort)";
+        break;
+    default:
+        break;
+    }
+
+    add_test_info(s);
+    std::cout << s.str();
+
+    exit(-sig);
+}
+#endif /*!DO_NOT_USE_SIGNALS*/
+
 // Standard C/C++ main entry point
 int main (int argc, char * const argv[]) {
+#ifndef DO_NOT_USE_SIGNALS
+    testing_finished = false;
+    signal(SIGSEGV, handle_signal);
+    signal(SIGABRT, handle_signal);
+    signal(SIGTERM, handle_signal);
+    signal(SIGINT, handle_signal);
+    signal(SIGILL, handle_signal);
+    signal(SIGFPE, handle_signal);
+#endif /*!DO_NOT_USE_SIGNALS*/
+
     return Catch::Session().run( argc, argv );
 }
 

--- a/include/internal/catch_default_main.hpp
+++ b/include/internal/catch_default_main.hpp
@@ -163,7 +163,7 @@ int main (int argc, char * const argv[]) {
 #endif
 
     return result;
-
+}
 
 #endif // __OBJC__
 

--- a/include/internal/catch_default_main.hpp
+++ b/include/internal/catch_default_main.hpp
@@ -147,6 +147,24 @@ int main (int argc, char * const argv[]) {
     return ret;
 }
 
+#else // __OBJC__
+
+// Objective-C entry point
+int main (int argc, char * const argv[]) {
+#if !CATCH_ARC_ENABLED
+    NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
+#endif
+
+    Catch::registerTestMethods();
+    int result = Catch::Session().run( argc, (char* const*)argv );
+
+#if !CATCH_ARC_ENABLED
+    [pool drain];
+#endif
+
+    return result;
+
+
 #endif // __OBJC__
 
 #endif // TWOBLUECUBES_CATCH_DEFAULT_MAIN_HPP_INCLUDED

--- a/include/internal/catch_version.hpp
+++ b/include/internal/catch_version.hpp
@@ -13,7 +13,7 @@
 namespace Catch {
 
     // These numbers are maintained by a script
-    Version libraryVersion( 1, 0, 23, "master" );
+    Version libraryVersion( 1, 0, 24, "master" );
 }
 
 #endif // TWOBLUECUBES_CATCH_VERSION_HPP_INCLUDED

--- a/include/internal/catch_version.hpp
+++ b/include/internal/catch_version.hpp
@@ -13,7 +13,7 @@
 namespace Catch {
 
     // These numbers are maintained by a script
-    Version libraryVersion( 1, 0, 25, "master" );
+    Version libraryVersion( 1, 0, 26, "master" );
 }
 
 #endif // TWOBLUECUBES_CATCH_VERSION_HPP_INCLUDED

--- a/include/internal/catch_version.hpp
+++ b/include/internal/catch_version.hpp
@@ -13,7 +13,7 @@
 namespace Catch {
 
     // These numbers are maintained by a script
-    Version libraryVersion( 1, 0, 24, "master" );
+    Version libraryVersion( 1, 0, 25, "master" );
 }
 
 #endif // TWOBLUECUBES_CATCH_VERSION_HPP_INCLUDED

--- a/include/internal/catch_version.hpp
+++ b/include/internal/catch_version.hpp
@@ -13,7 +13,7 @@
 namespace Catch {
 
     // These numbers are maintained by a script
-    Version libraryVersion( 1, 0, 19, "master" );
+    Version libraryVersion( 1, 0, 23, "master" );
 }
 
 #endif // TWOBLUECUBES_CATCH_VERSION_HPP_INCLUDED

--- a/single_include/catch.hpp
+++ b/single_include/catch.hpp
@@ -1,6 +1,6 @@
 /*
- *  CATCH v1.0 build 25 (master branch)
- *  Generated: 2013-12-17 14:51:52.643587
+ *  CATCH v1.0 build 26 (master branch)
+ *  Generated: 2013-12-17 14:56:48.216156
  *  ----------------------------------------------------------
  *  This file has been merged from multiple headers. Please don't edit it directly
  *  Copyright (c) 2012 Two Blue Cubes Ltd. All rights reserved.
@@ -6166,7 +6166,7 @@ namespace Catch {
 namespace Catch {
 
     // These numbers are maintained by a script
-    Version libraryVersion( 1, 0, 25, "master" );
+    Version libraryVersion( 1, 0, 26, "master" );
 }
 
 // #included from: catch_text.hpp
@@ -8057,6 +8057,7 @@ int main (int argc, char * const argv[]) {
 #endif
 
     return result;
+}
 
 #endif // __OBJC__
 

--- a/single_include/catch.hpp
+++ b/single_include/catch.hpp
@@ -1,6 +1,6 @@
 /*
- *  CATCH v1.0 build 24 (master branch)
- *  Generated: 2013-12-17 14:45:19.329049
+ *  CATCH v1.0 build 25 (master branch)
+ *  Generated: 2013-12-17 14:51:52.643587
  *  ----------------------------------------------------------
  *  This file has been merged from multiple headers. Please don't edit it directly
  *  Copyright (c) 2012 Two Blue Cubes Ltd. All rights reserved.
@@ -6166,7 +6166,7 @@ namespace Catch {
 namespace Catch {
 
     // These numbers are maintained by a script
-    Version libraryVersion( 1, 0, 24, "master" );
+    Version libraryVersion( 1, 0, 25, "master" );
 }
 
 // #included from: catch_text.hpp
@@ -8040,6 +8040,23 @@ int main (int argc, char * const argv[]) {
 #endif /*!DO_NOT_USE_SIGNALS*/
     return ret;
 }
+
+#else // __OBJC__
+
+// Objective-C entry point
+int main (int argc, char * const argv[]) {
+#if !CATCH_ARC_ENABLED
+    NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
+#endif
+
+    Catch::registerTestMethods();
+    int result = Catch::Session().run( argc, (char* const*)argv );
+
+#if !CATCH_ARC_ENABLED
+    [pool drain];
+#endif
+
+    return result;
 
 #endif // __OBJC__
 


### PR DESCRIPTION
1. #160 for the latest master branch.
2. Also added time-out for the whole test suite - In order to make use of it, before including <catch...> one needs to define something like:
# define TIMEOUT_FOR_ALL_TESTS_IN_SECONDS 3 \* 60

This is extremely useful to have: instead the whole testing might be hang if the code / test code enters the never-ending loop. Above will make it stop and fail instead, giving a bit of a clue on where the hanging code might be.

Implementation uses pthreads, so it's not available for MSVC compilers (unless with pthreads-win32), so for non-gnu compilers it only produces a warning if above is defined. This can be easily changed / updated once catch moves to C++11 (with std::thread), but can perhaps be fixed / updated by someone else here (i.e. using Windows native threads etc.)
