### PR TITLE
JUnit reporter: Added an ISO8601 timestamp to the timestamp attribute.

### DIFF
--- a/include/reporters/catch_reporter_junit.hpp
+++ b/include/reporters/catch_reporter_junit.hpp
@@ -89,6 +89,9 @@ namespace Catch {
             else
                 xml.writeAttribute( "time", suiteTime );
 
+            time_t rawtime;
+            struct tm *timeinfo;
+
 #ifdef CATCH_PLATFORM_WINDOWS
             // %z does not return the offset from UTC with MSVC's strftime implementation
             // Timestamps will look like: "2014-01-14T17:22:09"

--- a/include/reporters/catch_reporter_junit.hpp
+++ b/include/reporters/catch_reporter_junit.hpp
@@ -16,6 +16,7 @@
 
 #include <assert.h>
 #include <ctime>
+#include <cstring>
 
 namespace Catch {
 
@@ -88,16 +89,26 @@ namespace Catch {
             else
                 xml.writeAttribute( "time", suiteTime );
 
-            time_t rawtime;
-            struct tm * timeinfo;
-            const size_t timestampLength = 33;
-            char iso8601Timestamp[timestampLength];
+#ifdef CATCH_PLATFORM_WINDOWS
+            // %z does not return the offset from UTC with MSVC's strftime implementation
+            // Timestamps will look like: "2014-01-14T17:22:09"
+            const size_t timestampLength = 20;
+            const char fmt[] = "%Y-%m-%dT%H:%M:%S";
+#else
+            // on posix systems, we can have the full timestamp (tested with gcc and clang)
+            const size_t timestampLength = 26;
+            const char fmt[] = "%Y-%m-%dT%T%z";
+#endif
+            char timestampStr[timestampLength];
+            memset(timestampStr, 0, timestampLength);
 
             time(&rawtime);
             timeinfo = localtime(&rawtime);
 
-            strftime (iso8601Timestamp,timestampLength, "%Y-%m-%dT%T%z", timeinfo);
-            xml.writeAttribute( "timestamp", iso8601Timestamp );
+            size_t ret = strftime(timestampStr,timestampLength, fmt, timeinfo);
+            assert(ret != 0);
+
+            xml.writeAttribute( "timestamp", timestampStr );
 
             // Write test cases
             for( TestGroupNode::ChildNodes::const_iterator

--- a/include/reporters/catch_reporter_junit.hpp
+++ b/include/reporters/catch_reporter_junit.hpp
@@ -15,6 +15,7 @@
 #include "../internal/catch_xmlwriter.hpp"
 
 #include <assert.h>
+#include <ctime>
 
 namespace Catch {
 
@@ -86,7 +87,17 @@ namespace Catch {
                 xml.writeAttribute( "time", "" );
             else
                 xml.writeAttribute( "time", suiteTime );
-            xml.writeAttribute( "timestamp", "tbd" ); // !TBD
+
+            time_t rawtime;
+            struct tm * timeinfo;
+            const size_t timestampLength = 33;
+            char iso8601Timestamp[timestampLength];
+
+            time(&rawtime);
+            timeinfo = localtime(&rawtime);
+
+            strftime (iso8601Timestamp,timestampLength, "%Y-%m-%dT%T%z", timeinfo);
+            xml.writeAttribute( "timestamp", iso8601Timestamp );
 
             // Write test cases
             for( TestGroupNode::ChildNodes::const_iterator
@@ -108,7 +119,7 @@ namespace Catch {
             SectionNode const& rootSection = *testCaseNode.children.front();
 
             std::string className = stats.testInfo.className;
-            
+
             if( className.empty() ) {
                 if( rootSection.childSections.empty() )
                     className = "global";
@@ -122,7 +133,7 @@ namespace Catch {
             std::string name = trim( sectionNode.stats.sectionInfo.name );
             if( !rootName.empty() )
                 name = rootName + "/" + name;
-            
+
             if( !sectionNode.assertions.empty() ||
                 !sectionNode.stdOut.empty() ||
                 !sectionNode.stdErr.empty() ) {
@@ -190,7 +201,7 @@ namespace Catch {
                         elementName = "internalError";
                         break;
                 }
-            
+
                 XmlWriter::ScopedElement e = xml.scopedElement( elementName );
 
                 xml.writeAttribute( "message", result.getExpandedExpression() );
@@ -219,7 +230,7 @@ namespace Catch {
         unsigned int unexpectedExceptions;
     };
 
-    INTERNAL_CATCH_REGISTER_REPORTER( "junit", JunitReporter )    
+    INTERNAL_CATCH_REGISTER_REPORTER( "junit", JunitReporter )
 
 } // end namespace Catch
 


### PR DESCRIPTION
The current JUnit reporter uses the _"tbd"_ string for the `timestamp` attribute in testsuite nodes.

I use Catch in a context where libraries are built for several platforms (nothing really original here), and then aggregated in one package. The testresults are also aggregated, and I display the full set of results using the Jenkins JUnit publisher.

The main problem with this is that the JUnit parser in Jenkins somehow discards testsuite nodes if their name were already encountered **and** the timestamp is something it does not understand.

For instance, if I run the same 10 testcases on 3 platforms, the aggregated results report (as well as the _test trends_ graph) only shows me 10 test results (instead of the 30 I'm expecting). I'm pretty sure it is also due to something fishy inside the JUnit parser, but modifying Catch is way more easy.

I did not find any discussion about that topic in the Catch google group.

This simple patch replaces that _"tbd"_ string with an actual timestamp string. I used the ISO8601 format because [it seems to be what the JUnit spec is expecting](http://windyroad.com.au/dl/Open%20Source/JUnit.xsd).

This patch currently solves the aforementioned issue with Jenkins testresults aggregation.

I did not regenerate the single header redistribuable as part of this PR because my assumption is that releases are made from the master branch.
