### PR TITLE
add support for `duration threshold`

### DIFF
--- a/include/internal/catch_commandline.hpp
+++ b/include/internal/catch_commandline.hpp
@@ -40,6 +40,10 @@ namespace Catch {
             ? ShowDurations::Always
             : ShowDurations::Never;
     }
+    inline void setShowDurationsThreshold( ConfigData& config, double _showDurationsThreshold ) {
+        config.showDurations = ShowDurations::Threshold;
+        config.showDurationsThreshold = _showDurationsThreshold;
+    }
     inline void loadTestNamesFromFile( ConfigData& config, std::string const& _filename ) {
         std::ifstream f( _filename.c_str() );
         if( !f.is_open() )
@@ -141,6 +145,12 @@ namespace Catch {
             .shortOpt( "d")
             .longOpt( "durations" )
             .hint( "yes/no" );
+
+        cli.bind( &setShowDurationsThreshold )
+            .describe( "show test durations only if exceeding this threshold" )
+            .shortOpt( "q")
+            .longOpt( "durations-threshold" )
+            .hint( "seconds" );
 
         cli.bind( &loadTestNamesFromFile )
             .describe( "load test names to run from a file" )

--- a/include/internal/catch_config.hpp
+++ b/include/internal/catch_config.hpp
@@ -38,7 +38,8 @@ namespace Catch {
             abortAfter( -1 ),
             verbosity( Verbosity::Normal ),
             warnings( WarnAbout::Nothing ),
-            showDurations( ShowDurations::DefaultForReporter )
+            showDurations( ShowDurations::DefaultForReporter ),
+            showDurationsThreshold( 0.0 )
         {}
 
         bool listTests;
@@ -56,6 +57,7 @@ namespace Catch {
         Verbosity::Level verbosity;
         WarnAbout::What warnings;
         ShowDurations::OrNot showDurations;
+        double showDurationsThreshold;
 
         std::string reporterName;
         std::string outputFilename;
@@ -162,7 +164,7 @@ namespace Catch {
         virtual bool includeSuccessfulResults() const   { return m_data.showSuccessfulTests; }
         virtual bool warnAboutMissingAssertions() const { return m_data.warnings & WarnAbout::NoAssertions; }
         virtual ShowDurations::OrNot showDurations() const { return m_data.showDurations; }
-
+        virtual double showDurationsThreshold() const { return m_data.showDurationsThreshold; }
 
     private:
         ConfigData m_data;

--- a/include/internal/catch_console_colour.hpp
+++ b/include/internal/catch_console_colour.hpp
@@ -47,6 +47,8 @@ namespace Catch {
             ReconstructedExpression = Yellow,
 
             SecondaryText = LightGrey,
+            DurationText = Yellow,
+
             Headers = White
         };
 

--- a/include/internal/catch_interfaces_config.h
+++ b/include/internal/catch_interfaces_config.h
@@ -29,7 +29,8 @@ namespace Catch {
     struct ShowDurations { enum OrNot {
         DefaultForReporter,
         Always,
-        Never
+        Never,
+        Threshold
     }; };
 
     struct IConfig : IShared {
@@ -44,6 +45,7 @@ namespace Catch {
         virtual bool warnAboutMissingAssertions() const = 0;
         virtual int abortAfter() const = 0;
         virtual ShowDurations::OrNot showDurations() const = 0;
+        virtual double showDurationsThreshold() const = 0;
     };
 }
 

--- a/include/internal/catch_interfaces_reporter.h
+++ b/include/internal/catch_interfaces_reporter.h
@@ -167,20 +167,18 @@ namespace Catch
     struct TestRunStats {
         TestRunStats(   TestRunInfo const& _runInfo,
                         Totals const& _totals,
+                        double _durationInSeconds,
                         bool _aborting )
         :   runInfo( _runInfo ),
             totals( _totals ),
+            durationInSeconds( _durationInSeconds ),
             aborting( _aborting )
-        {}
-        TestRunStats( TestRunStats const& _other )
-        :   runInfo( _other.runInfo ),
-            totals( _other.totals ),
-            aborting( _other.aborting )
         {}
         virtual ~TestRunStats();
 
         TestRunInfo runInfo;
         Totals totals;
+        double durationInSeconds;
         bool aborting;
     };
 

--- a/include/internal/catch_runner_impl.hpp
+++ b/include/internal/catch_runner_impl.hpp
@@ -71,10 +71,11 @@ namespace Catch {
             m_context.setConfig( m_config );
             m_context.setResultCapture( this );
             m_reporter->testRunStarting( m_runInfo );
+            m_timer.start();
         }
 
         virtual ~RunContext() {
-            m_reporter->testRunEnded( TestRunStats( m_runInfo, m_totals, aborting() ) );
+            m_reporter->testRunEnded( TestRunStats( m_runInfo, m_totals, m_timer.getElapsedSeconds(), aborting() ) );
             m_context.setRunner( m_prevRunner );
             m_context.setConfig( NULL );
             m_context.setResultCapture( m_prevResultCapture );
@@ -329,6 +330,8 @@ namespace Catch {
         Ptr<IConfig const> m_prevConfig;
         AssertionInfo m_lastAssertionInfo;
         std::vector<UnfinishedSections> m_unfinishedSections;
+
+        Timer m_timer;
     };
 
 } // end namespace Catch


### PR DESCRIPTION
This adds a new option `-q <seconds>` for specifying a `duration threshold` value for printing out duration timing results in the basic console reporter: only if the given threshold (given as a `double` value in seconds) is exceeded the duration is printed out through the console reporter.

This PR replaces my earlier PR #189 since that was not up-to-date anymore with all the recent changes in the `master` branch...