### PR TITLE
switch from ->* to <= in expression decomposer

### DIFF
--- a/include/internal/catch_capture.hpp
+++ b/include/internal/catch_capture.hpp
@@ -33,7 +33,7 @@
     do { \
         Catch::ResultBuilder __catchResult( macroName, CATCH_INTERNAL_LINEINFO, #expr, resultDisposition ); \
         try { \
-            ( __catchResult->*expr ).endExpression(); \
+            ( __catchResult <= expr ).endExpression(); \
         } \
         catch( ... ) { \
             __catchResult.useActiveException( Catch::ResultDisposition::Normal ); \

--- a/include/internal/catch_result_builder.h
+++ b/include/internal/catch_result_builder.h
@@ -41,8 +41,8 @@ namespace Catch {
                         ResultDisposition::Flags resultDisposition );
 
         template<typename T>
-        ExpressionLhs<T const&> operator->* ( T const& operand );
-        ExpressionLhs<bool> operator->* ( bool value );
+        ExpressionLhs<T const&> operator<= ( T const& operand );
+        ExpressionLhs<bool> operator<= ( bool value );
 
         template<typename T>
         ResultBuilder& operator << ( T const& value ) {
@@ -93,11 +93,11 @@ namespace Catch {
 namespace Catch {
 
     template<typename T>
-    inline ExpressionLhs<T const&> ResultBuilder::operator->* ( T const& operand ) {
+    inline ExpressionLhs<T const&> ResultBuilder::operator<= ( T const& operand ) {
         return ExpressionLhs<T const&>( *this, operand );
     }
 
-    inline ExpressionLhs<bool> ResultBuilder::operator->* ( bool value ) {
+    inline ExpressionLhs<bool> ResultBuilder::operator<= ( bool value ) {
         return ExpressionLhs<bool>( *this, value );
     }
 

--- a/projects/SelfTest/TrickyTests.cpp
+++ b/projects/SelfTest/TrickyTests.cpp
@@ -55,18 +55,18 @@ TEST_CASE
 ///////////////////////////////////////////////////////////////////////////////
 TEST_CASE
 (
-    "Where the LHS is not a simple value[failing]",
-    "[Tricky][failing][.]"
+    "Where the LHS is not a simple value",
+    "[Tricky]"
 )
 {
-    /*
     int a = 1;
     int b = 2;
     
-    // This only captures part of the expression, but issues a warning about the rest
-    REQUIRE( a+1 == b-1 );
-    */
-    WARN( "Uncomment the code in this test to check that it gives a sensible compiler error" );
+    REQUIRE( a+1 == b );
+    REQUIRE( a < b );
+
+    REQUIRE( a%2 == 1 );
+    REQUIRE( b%2 == 0 );
 }
 
 struct Opaque


### PR DESCRIPTION
Thanks for the awesome test framework. The idea is really clever!

One problem I had noticed is that comparisons were asymmetric. Tests such as `REQUIRE( 1+1 == 2 )` would fail, but `REQUIRE( 2 == 1+1 )` would pass. This pull request makes tests symmetric.

The expression decomposition seemed like magic, so I spent some time figuring it out and writing my own [minimal working implementation](https://gist.github.com/tclamb/9149587). During that, I realized expressions containing common binary operators can be used on the LHS if we switch from `->*` to a comparison operator.

This pull request allows expressions containing any of `*`, `/`, `%`, `+`, `-`, `<<` and `>>` to be used on the LHS.

`<=` was chosen arbitrarily from comparison operators, but any of `<=`, `>=`, `<`, and `>` have the same precedence.

No tests broke, and the corresponding originally failing test in `[tricky]` was updated and added to the main suite.