### PR TITLE
Support nullptr on Visual Studio >=2005

### DIFF
--- a/include/internal/catch_compiler_capabilities.h
+++ b/include/internal/catch_compiler_capabilities.h
@@ -80,6 +80,10 @@
 // Visual C++
 #ifdef _MSC_VER
 
+#if (_MSC_VER >= 1400)
+#define CATCH_CONFIG_CPP11_NULLPTR
+#endif
+
 #if (_MSC_VER >= 1310 ) // (VC++ 7.0+)
 //#define CATCH_CONFIG_SFINAE // Not confirmed
 #endif


### PR DESCRIPTION
Currently to support nullptr comparisons on Windows we have to add ``#define CATCH_CONFIG_CPP11_NULLPTR`` before including catch.hpp every time, as described in https://github.com/philsquared/Catch/issues/80 

But nullptr is certainly available since Visual Studio 2005, http://msdn.microsoft.com/en-us/library/4ex65770(v=vs.80).aspx    so  this can be done automatically.

