### PR TITLE
toString( std::pair ).

### DIFF
--- a/include/internal/catch_tostring.h
+++ b/include/internal/catch_tostring.h
@@ -27,6 +27,35 @@ namespace Catch {
 template<typename T>
 std::string toString( T const& value );
 
+// Built in overloads
+
+std::string toString( std::string const& value );
+std::string toString( std::wstring const& value );
+std::string toString( const char* const value );
+std::string toString( char* const value );
+std::string toString( const wchar_t* const value );
+std::string toString( wchar_t* const value );
+std::string toString( int value );
+std::string toString( unsigned long value );
+std::string toString( unsigned int value );
+std::string toString( const double value );
+std::string toString( const float value );
+std::string toString( bool value );
+std::string toString( char value );
+std::string toString( signed char value );
+std::string toString( unsigned char value );
+
+#ifdef CATCH_CONFIG_CPP11_NULLPTR
+std::string toString( std::nullptr_t );
+#endif
+
+#ifdef __OBJC__
+    std::string toString( NSString const * const& nsstring );
+    std::string toString( NSString * CATCH_ARC_STRONG const& nsstring );
+    std::string toString( NSObject* const& nsObject );
+#endif
+
+  
 namespace Detail {
 
 // SFINAE is currently disabled by default for all compilers.
@@ -178,33 +207,6 @@ std::string toString( T const& value ) {
     return StringMaker<T>::convert( value );
 }
 
-// Built in overloads
-
-std::string toString( std::string const& value );
-std::string toString( std::wstring const& value );
-std::string toString( const char* const value );
-std::string toString( char* const value );
-std::string toString( const wchar_t* const value );
-std::string toString( wchar_t* const value );
-std::string toString( int value );
-std::string toString( unsigned long value );
-std::string toString( unsigned int value );
-std::string toString( const double value );
-std::string toString( const float value );
-std::string toString( bool value );
-std::string toString( char value );
-std::string toString( signed char value );
-std::string toString( unsigned char value );
-
-#ifdef CATCH_CONFIG_CPP11_NULLPTR
-std::string toString( std::nullptr_t );
-#endif
-
-#ifdef __OBJC__
-    std::string toString( NSString const * const& nsstring );
-    std::string toString( NSString * CATCH_ARC_STRONG const& nsstring );
-    std::string toString( NSObject* const& nsObject );
-#endif
 
     namespace Detail {
     template<typename InputIterator>

--- a/include/internal/catch_tostring.h
+++ b/include/internal/catch_tostring.h
@@ -21,6 +21,11 @@
 #include "catch_objc_arc.hpp"
 #endif
 
+#ifdef CATCH_CPP11_OR_GREATER
+#include <tuple>
+#include <type_traits>
+#endif
+
 namespace Catch {
 
 // Why we're here.

--- a/include/internal/catch_tostring.h
+++ b/include/internal/catch_tostring.h
@@ -193,6 +193,50 @@ struct StringMaker<std::vector<T, Allocator> > {
     }
 };
 
+
+#ifdef CATCH_CPP11_OR_GREATER
+  /*
+    toString for tuples
+  */
+namespace TupleDetail {
+  template<
+      typename Tuple,
+      std::size_t N = 0,
+      bool = (N < std::tuple_size<Tuple>::value)
+      >
+  struct ElementPrinter {
+      static void print( const Tuple& tuple, std::ostream& os )
+      {
+          os << ( N ? ", " : " " )
+             << Catch::toString(std::get<N>(tuple));
+          ElementPrinter<Tuple,N+1>::print(tuple,os);
+      }
+  };
+
+  template<
+      typename Tuple,
+      std::size_t N
+      >
+  struct ElementPrinter<Tuple,N,false> {
+      static void print( const Tuple&, std::ostream& ) {}
+  };
+
+}
+
+template<typename ...Types>
+struct StringMaker<std::tuple<Types...>> {
+
+    static std::string convert( const std::tuple<Types...>& tuple )
+    {
+        std::ostringstream os;
+        os << '{';
+        TupleDetail::ElementPrinter<std::tuple<Types...>>::print( tuple, os );
+        os << " }";
+        return os.str();
+    }
+};
+#endif
+
 namespace Detail {
     template<typename T>
     std::string makeString( T const& value ) {

--- a/include/internal/catch_tostring.h
+++ b/include/internal/catch_tostring.h
@@ -237,12 +237,27 @@ struct StringMaker<std::tuple<Types...>> {
 };
 #endif
 
+template<typename T1, typename T2>
+struct StringMaker<std::pair<T1,T2> > {
+    static std::string convert( const std::pair<T1,T2>& pair ) {
+        std::ostringstream oss;
+        oss << "{ "
+            << Catch::toString( pair.first )
+            << ", "
+            << Catch::toString( pair.second )
+            << " }";
+        return oss.str();
+    }
+};
+
+
 namespace Detail {
     template<typename T>
     std::string makeString( T const& value ) {
         return StringMaker<T>::convert( value );
     }
 } // end namespace Detail
+
 
 /// \brief converts any type to a string
 ///

--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -6,6 +6,11 @@ project(Catch)
 get_filename_component(CATCH_DIR "${CMAKE_CURRENT_SOURCE_DIR}" PATH)
 get_filename_component(CATCH_DIR "${CATCH_DIR}" PATH)
 set(SELF_TEST_DIR ${CATCH_DIR}/projects/SelfTest)
+if(USE_CPP11)
+  ## We can't turn this on by default, since it breaks on travis
+  message(STATUS "Enabling C++11")
+  set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+endif()
 
 # define the sources of the self test
 set(SOURCES
@@ -25,6 +30,7 @@ set(SOURCES
     ${SELF_TEST_DIR}/ToStringPair.cpp
     ${SELF_TEST_DIR}/ToStringVector.cpp
     ${SELF_TEST_DIR}/ToStringWhich.cpp
+    ${SELF_TEST_DIR}/ToStringTuple.cpp
 )
 
 # configure the executable

--- a/projects/SelfTest/ToStringPair.cpp
+++ b/projects/SelfTest/ToStringPair.cpp
@@ -37,16 +37,16 @@ TEST_CASE( "toString( pair<vector,vector> )", "[toString][pair][vector]" )
 {
     typedef std::pair<std::vector<int>,std::vector<float> > type;
 
-    int aint[] = { 4, 2 };
-    std::vector<int> vint( std::begin(aint), std::end(aint) );
-    CHECK( "{ 4, 2 }" == Catch::toString(vint) );
+    int aint[] = { 4, 2, 6 };
+    std::vector<int> vint( aint, aint+3 );
+    CHECK( "{ 4, 2, 6 }" == Catch::toString(vint) );
 
-    float afloat[] = { 0.4f, 0.2f };
-    std::vector<float> vfloat( std::begin(afloat), std::end(afloat) );
-    CHECK( "{ 0.4f, 0.2f }" == Catch::toString(vfloat) );
+    float afloat[] = { 0.4f, 0.2f, 0.7f };
+    std::vector<float> vfloat( afloat, afloat+3 );
+    CHECK( "{ 0.4f, 0.2f, 0.7f }" == Catch::toString(vfloat) );
 
     type value( vint, vfloat );
-    CHECK( "{ { 4, 2 }, { 0.4f, 0.2f } }" == Catch::toString(value) );
+    CHECK( "{ { 4, 2, 6 }, { 0.4f, 0.2f, 0.7f } }" == Catch::toString(value) );
 }
 
 

--- a/projects/SelfTest/ToStringPair.cpp
+++ b/projects/SelfTest/ToStringPair.cpp
@@ -31,3 +31,22 @@ TEST_CASE( "pair<pair<int,const char *,pair<std::string,int> > -> toString", "[t
     std::pair<left_t,right_t> pair( left, right );
     REQUIRE( Catch::toString( pair ) == "{ { 42, \"Arthur\" }, { \"Ford\", 24 } }" );
 }
+
+// More contrivance: A pair of vectors...
+TEST_CASE( "toString( pair<vector,vector> )", "[toString][pair][vector]" )
+{
+    typedef std::pair<std::vector<int>,std::vector<float> > type;
+
+    int aint[] = { 4, 2 };
+    std::vector<int> vint( std::begin(aint), std::end(aint) );
+    CHECK( "{ 4, 2 }" == Catch::toString(vint) );
+
+    float afloat[] = { 0.4f, 0.2f };
+    std::vector<float> vfloat( std::begin(afloat), std::end(afloat) );
+    CHECK( "{ 0.4f, 0.2f }" == Catch::toString(vfloat) );
+
+    type value( vint, vfloat );
+    CHECK( "{ { 4, 2 }, { 0.4f, 0.2f } }" == Catch::toString(value) );
+}
+
+

--- a/projects/SelfTest/ToStringPair.cpp
+++ b/projects/SelfTest/ToStringPair.cpp
@@ -1,23 +1,5 @@
 #include "catch.hpp"
 
-// === Pair ===
-namespace Catch {
-    // Note: If we put this in the right place in catch_tostring, then
-    // we can make it an overload of Catch::toString
-    template<typename T1, typename T2>
-    struct StringMaker<std::pair<T1,T2> > {
-        static std::string convert( const std::pair<T1,T2>& pair ) {
-            std::ostringstream oss;
-            oss << "{ "
-                << toString( pair.first )
-                << ", "
-                << toString( pair.second )
-                << " }";
-            return oss.str();
-        }
-    };
-}
-
 TEST_CASE( "std::pair<int,std::string> -> toString", "[toString][pair]" )
 {
     std::pair<int,std::string> value( 34, "xyzzy" );

--- a/projects/SelfTest/ToStringTuple.cpp
+++ b/projects/SelfTest/ToStringTuple.cpp
@@ -44,5 +44,34 @@ TEST_CASE( "tuple<nullptr,int,const char *>", "[toString][tuple]" )
     CHECK( "{ nullptr, 42, \"Catch me\" }" == Catch::toString(value) );
 }
 
+TEST_CASE( "toString( tuple<pair,pair,pair> )", "[toString][tuple][pair]" )
+{
+    typedef std::tuple<std::pair<int,int>,
+                       std::pair<int,int>,
+                       std::pair<int,int>>
+        type;
+    std::pair<int,int> p1{ 12, 34 };
+    CHECK( "{ 12, 34 }" == Catch::toString(p1) );
+    std::pair<int,int> p2{ 23, 45 };
+    CHECK( "{ 23, 45 }" == Catch::toString(p2) );
+    std::pair<int,int> p3{ 24, 68 };
+    CHECK( "{ 24, 68 }" == Catch::toString(p3) );
+    type value{ p1, p2, p3 };
+    CHECK( "{ { 12, 34 }, { 23, 45 }, { 24, 68 } }" == Catch::toString(value) );
+}
+
+TEST_CASE( "toString( pair<tuple,tuple> )", "[toString][tuple][pair]" )
+{
+    typedef std::pair<std::tuple<int,int,int>,
+                      std::tuple<int,int,int>
+                      > type;
+    std::tuple<int,int,int> tuple1{ 12, 34, 56 };
+    CHECK( "{ 12, 34, 56 }" == Catch::toString(tuple1) );
+    std::tuple<int,int,int> tuple2{ 23, 45, 67 };
+    CHECK( "{ 23, 45, 67 }" == Catch::toString(tuple2) );
+    type value{ tuple1, tuple2 };
+    CHECK( "{ { 12, 34, 56 }, { 23, 45, 67 } }" == Catch::toString(value) );
+}
+
 #endif /* #ifdef CATCH_CPP11_OR_GREATER */
 

--- a/projects/SelfTest/ToStringTuple.cpp
+++ b/projects/SelfTest/ToStringTuple.cpp
@@ -33,7 +33,7 @@ TEST_CASE( "tuple<string,string>", "[toString][tuple]" )
 TEST_CASE( "tuple<tuple<int>,tuple<>,float>", "[toString][tuple]" )
 {
     typedef std::tuple<std::tuple<int>,std::tuple<>,float> type;
-    type value { {42}, {}, 1.2f };
+    type value { std::tuple<int>{42}, {}, 1.2f };
     CHECK( "{ { 42 }, { }, 1.2f }" == Catch::toString(value) );
 }
 

--- a/projects/SelfTest/ToStringTuple.cpp
+++ b/projects/SelfTest/ToStringTuple.cpp
@@ -1,0 +1,48 @@
+#include "catch.hpp"
+
+#ifdef CATCH_CPP11_OR_GREATER
+
+TEST_CASE( "tuple<>", "[toString][tuple]" )
+{
+    typedef std::tuple<> type;
+    CHECK( "{ }" == Catch::toString(type{}) );
+    type value {};
+    CHECK( "{ }" == Catch::toString(value) );
+}
+
+TEST_CASE( "tuple<int>", "[toString][tuple]" )
+{
+    typedef std::tuple<int> type;
+    CHECK( "{ 0 }" == Catch::toString(type{0}) );
+}
+
+
+TEST_CASE( "tuple<float,int>", "[toString][tuple]" )
+{
+    typedef std::tuple<float,int> type;
+    CHECK( "1.2f" == Catch::toString(float(1.2)) );
+    CHECK( "{ 1.2f, 0 }" == Catch::toString(type{1.2,0}) );
+}
+
+TEST_CASE( "tuple<string,string>", "[toString][tuple]" )
+{
+    typedef std::tuple<std::string,std::string> type;
+    CHECK( "{ \"hello\", \"world\" }" == Catch::toString(type{"hello","world"}) );
+}
+
+TEST_CASE( "tuple<tuple<int>,tuple<>,float>", "[toString][tuple]" )
+{
+    typedef std::tuple<std::tuple<int>,std::tuple<>,float> type;
+    type value { {42}, {}, 1.2f };
+    CHECK( "{ { 42 }, { }, 1.2f }" == Catch::toString(value) );
+}
+
+TEST_CASE( "tuple<nullptr,int,const char *>", "[toString][tuple]" )
+{
+    typedef std::tuple<std::nullptr_t,int,const char *> type;
+    type value { nullptr, 42, "Catch me" };
+    CHECK( "{ nullptr, 42, \"Catch me\" }" == Catch::toString(value) );
+}
+
+#endif /* #ifdef CATCH_CPP11_OR_GREATER */
+

--- a/projects/SelfTest/TrickyTests.cpp
+++ b/projects/SelfTest/TrickyTests.cpp
@@ -17,18 +17,6 @@
 #pragma clang diagnostic ignored "-Wc++98-compat-pedantic"
 #endif
 
-namespace Catch
-{
-    template<>
-    std::string toString<std::pair<int, int> >( const std::pair<int, int>& value )
-    {
-        std::ostringstream oss;
-        oss << "std::pair( " << value.first << ", " << value.second << " )";
-        return oss.str();
-        
-    }
-}
-
 ///////////////////////////////////////////////////////////////////////////////
 TEST_CASE
 (


### PR DESCRIPTION
This basically moves the `StringMaker<pair<T1,T2>>` from the ToStringPair tests into `catch_tostring`. (which is where it was intended to go in the first place).

I also added a few test cases for oddball things like pair<vector>, tuple<pair,pair...> etc.

