### PR TITLE
Fix ICC C++ compiler warnings on OS X

### DIFF
--- a/include/internal/catch_compiler_capabilities.h
+++ b/include/internal/catch_compiler_capabilities.h
@@ -10,7 +10,7 @@
 
 // Much of the following code is based on Boost (1.53)
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 
 #  if __has_feature(cxx_nullptr)
 #    define CATCH_CONFIG_CPP11_NULLPTR

--- a/include/internal/catch_impl.hpp
+++ b/include/internal/catch_impl.hpp
@@ -11,7 +11,7 @@
 // Collect all the implementation files together here
 // These are the equivalent of what would usually be cpp files
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wweak-vtables"
 #endif
@@ -92,7 +92,7 @@ namespace Catch {
     INTERNAL_CATCH_REGISTER_LEGACY_REPORTER( "xml", XmlReporter )
 }
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic pop
 #endif
 

--- a/include/internal/catch_objc_arc.hpp
+++ b/include/internal/catch_objc_arc.hpp
@@ -33,13 +33,13 @@ inline id performOptionalSelector( id obj, SEL sel ) {
 #else
 inline void arcSafeRelease( NSObject* ){}
 inline id performOptionalSelector( id obj, SEL sel ) {
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
 #endif
     if( [obj respondsToSelector: sel] )
         return [obj performSelector: sel];
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic pop
 #endif
     return nil;

--- a/include/internal/catch_ptr.hpp
+++ b/include/internal/catch_ptr.hpp
@@ -10,7 +10,7 @@
 
 #include "catch_common.h"
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpadded"
 #endif
@@ -87,7 +87,7 @@ namespace Catch {
 
 } // end namespace Catch
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic pop
 #endif
 

--- a/include/internal/catch_reenable_warnings.h
+++ b/include/internal/catch_reenable_warnings.h
@@ -8,7 +8,7 @@
 #ifndef TWOBLUECUBES_CATCH_REENABLE_WARNINGS_H_INCLUDED
 #define TWOBLUECUBES_CATCH_REENABLE_WARNINGS_H_INCLUDED
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic pop
 #elif defined __GNUC__
 #pragma GCC diagnostic pop

--- a/include/internal/catch_stream.h
+++ b/include/internal/catch_stream.h
@@ -11,7 +11,7 @@
 
 #include <streambuf>
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic ignored "-Wpadded"
 #endif
 

--- a/include/internal/catch_suppress_warnings.h
+++ b/include/internal/catch_suppress_warnings.h
@@ -8,7 +8,7 @@
 #ifndef TWOBLUECUBES_CATCH_SUPPRESS_WARNINGS_H_INCLUDED
 #define TWOBLUECUBES_CATCH_SUPPRESS_WARNINGS_H_INCLUDED
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic ignored "-Wglobal-constructors"
 #pragma clang diagnostic ignored "-Wvariadic-macros"
 #pragma clang diagnostic ignored "-Wc99-extensions"

--- a/include/internal/catch_test_case_info.h
+++ b/include/internal/catch_test_case_info.h
@@ -14,7 +14,7 @@
 #include <string>
 #include <set>
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpadded"
 #endif
@@ -83,7 +83,7 @@ namespace Catch {
                             SourceLineInfo const& lineInfo );
 }
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic pop
 #endif
 

--- a/include/internal/catch_test_spec.hpp
+++ b/include/internal/catch_test_spec.hpp
@@ -8,7 +8,7 @@
 #ifndef TWOBLUECUBES_CATCH_TEST_SPEC_HPP_INCLUDED
 #define TWOBLUECUBES_CATCH_TEST_SPEC_HPP_INCLUDED
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpadded"
 #endif
@@ -57,12 +57,12 @@ namespace Catch {
                         return contains( toLower( testCase.name ), m_name );
                 }
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunreachable-code"
 #endif
                 throw std::logic_error( "Unknown enum" );
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic pop
 #endif
             }
@@ -120,7 +120,7 @@ namespace Catch {
     };
 }
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic pop
 #endif
 

--- a/include/internal/catch_test_spec_parser.hpp
+++ b/include/internal/catch_test_spec_parser.hpp
@@ -8,7 +8,7 @@
 #ifndef TWOBLUECUBES_CATCH_TEST_SPEC_PARSER_HPP_INCLUDED
 #define TWOBLUECUBES_CATCH_TEST_SPEC_PARSER_HPP_INCLUDED
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpadded"
 #endif
@@ -109,7 +109,7 @@ namespace Catch {
 
 } // namespace Catch
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic pop
 #endif
 

--- a/include/internal/catch_timer.hpp
+++ b/include/internal/catch_timer.hpp
@@ -9,7 +9,7 @@
 #include "catch_timer.h"
 #include "catch_platform.h"
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wc++11-long-long"
 #endif
@@ -58,6 +58,6 @@ namespace Catch {
 
 } // namespace Catch
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic pop
 #endif

--- a/projects/SelfTest/ConditionTests.cpp
+++ b/projects/SelfTest/ConditionTests.cpp
@@ -5,7 +5,7 @@
  *  Distributed under the Boost Software License, Version 1.0. (See accompanying
  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
  */
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic ignored "-Wpadded"
 #endif
 

--- a/projects/SelfTest/EnumToString.cpp
+++ b/projects/SelfTest/EnumToString.cpp
@@ -30,7 +30,7 @@ TEST_CASE( "toString(enum w/operator<<)", "[toString][enum]" ) {
 }
 
 #if defined(CATCH_CPP11_OR_GREATER)
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wc++98-compat"
 #endif
@@ -69,7 +69,7 @@ TEST_CASE( "toString(enum class w/operator<<)", "[toString][enum][enumClass]" ) 
     CHECK( Catch::toString(e3) == "Unknown enum value 10" );
 }
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic pop
 #endif
 #endif // CATCH_CPP11_OR_GREATER

--- a/projects/SelfTest/MessageTests.cpp
+++ b/projects/SelfTest/MessageTests.cpp
@@ -9,7 +9,7 @@
 #include "catch.hpp"
 #include <iostream>
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic ignored "-Wc++98-compat-pedantic"
 #endif
 

--- a/projects/SelfTest/MiscTests.cpp
+++ b/projects/SelfTest/MiscTests.cpp
@@ -10,7 +10,7 @@
 
 #include <iostream>
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic ignored "-Wc++98-compat-pedantic"
 #endif
 

--- a/projects/SelfTest/SectionTrackerTests.cpp
+++ b/projects/SelfTest/SectionTrackerTests.cpp
@@ -6,7 +6,7 @@
  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
  */
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic ignored "-Wpadded"
 #endif
 

--- a/projects/SelfTest/TestMain.cpp
+++ b/projects/SelfTest/TestMain.cpp
@@ -14,7 +14,7 @@ CATCH_REGISTER_TAG_ALIAS( "[@nhf]", "[failing]~[.]" )
 CATCH_REGISTER_TAG_ALIAS( "[@tricky]", "[tricky]~[.]" )
 
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic ignored "-Wpadded"
 #pragma clang diagnostic ignored "-Wweak-vtables"
 #endif

--- a/projects/SelfTest/ToStringVector.cpp
+++ b/projects/SelfTest/ToStringVector.cpp
@@ -24,7 +24,7 @@ TEST_CASE( "vector<string> -> toString", "[toString][vector]" )
 }
 
 #if defined(CATCH_CPP11_OR_GREATER)
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wc++98-compat"
 #endif
@@ -71,7 +71,7 @@ TEST_CASE( "vec<vec<string,alloc>> -> toString", "[toString][vector,allocator]" 
     REQUIRE( Catch::toString(v) == "{ { \"hello\" }, { \"world\" } }" );
 }
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic pop
 #endif
 #endif // CATCH_CPP11_OR_GREATER

--- a/projects/SelfTest/TrickyTests.cpp
+++ b/projects/SelfTest/TrickyTests.cpp
@@ -6,13 +6,13 @@
  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
  */
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic ignored "-Wpadded"
 #endif
 
 #include "catch.hpp"
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic ignored "-Wc++98-compat"
 #pragma clang diagnostic ignored "-Wc++98-compat-pedantic"
 #endif

--- a/single_include/catch.hpp
+++ b/single_include/catch.hpp
@@ -17,7 +17,7 @@
 
 #define TWOBLUECUBES_CATCH_SUPPRESS_WARNINGS_H_INCLUDED
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic ignored "-Wglobal-constructors"
 #pragma clang diagnostic ignored "-Wvariadic-macros"
 #pragma clang diagnostic ignored "-Wc99-extensions"
@@ -66,7 +66,7 @@
 
 // Much of the following code is based on Boost (1.53)
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 
 #  if __has_feature(cxx_nullptr)
 #    define CATCH_CONFIG_CPP11_NULLPTR
@@ -327,7 +327,7 @@ namespace Catch {
 // #included from: catch_ptr.hpp
 #define TWOBLUECUBES_CATCH_PTR_HPP_INCLUDED
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpadded"
 #endif
@@ -404,7 +404,7 @@ namespace Catch {
 
 } // end namespace Catch
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic pop
 #endif
 
@@ -1023,13 +1023,13 @@ inline id performOptionalSelector( id obj, SEL sel ) {
 #else
 inline void arcSafeRelease( NSObject* ){}
 inline id performOptionalSelector( id obj, SEL sel ) {
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
 #endif
     if( [obj respondsToSelector: sel] )
         return [obj performSelector: sel];
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic pop
 #endif
     return nil;
@@ -2471,7 +2471,7 @@ namespace Catch {
 #include <string>
 #include <set>
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpadded"
 #endif
@@ -2540,7 +2540,7 @@ namespace Catch {
                             SourceLineInfo const& lineInfo );
 }
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic pop
 #endif
 
@@ -2746,7 +2746,7 @@ return @ desc; \
 // Collect all the implementation files together here
 // These are the equivalent of what would usually be cpp files
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wweak-vtables"
 #endif
@@ -2763,7 +2763,7 @@ return @ desc; \
 // #included from: catch_test_spec_parser.hpp
 #define TWOBLUECUBES_CATCH_TEST_SPEC_PARSER_HPP_INCLUDED
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpadded"
 #endif
@@ -2771,7 +2771,7 @@ return @ desc; \
 // #included from: catch_test_spec.hpp
 #define TWOBLUECUBES_CATCH_TEST_SPEC_HPP_INCLUDED
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpadded"
 #endif
@@ -2818,12 +2818,12 @@ namespace Catch {
                         return contains( toLower( testCase.name ), m_name );
                 }
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunreachable-code"
 #endif
                 throw std::logic_error( "Unknown enum" );
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic pop
 #endif
             }
@@ -2881,7 +2881,7 @@ namespace Catch {
     };
 }
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic pop
 #endif
 
@@ -2978,7 +2978,7 @@ namespace Catch {
 
 } // namespace Catch
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic pop
 #endif
 
@@ -3039,7 +3039,7 @@ namespace Catch {
 
 #include <streambuf>
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic ignored "-Wpadded"
 #endif
 
@@ -6797,7 +6797,7 @@ namespace Catch
 
 // #included from: catch_timer.hpp
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wc++11-long-long"
 #endif
@@ -6846,7 +6846,7 @@ namespace Catch {
 
 } // namespace Catch
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic pop
 #endif
 // #included from: catch_common.hpp
@@ -9046,7 +9046,7 @@ namespace Catch {
     INTERNAL_CATCH_REGISTER_LEGACY_REPORTER( "xml", XmlReporter )
 }
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic pop
 #endif
 
@@ -9231,7 +9231,7 @@ using Catch::Detail::Approx;
 
 #define TWOBLUECUBES_CATCH_REENABLE_WARNINGS_H_INCLUDED
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma clang diagnostic pop
 #elif defined __GNUC__
 #pragma GCC diagnostic pop


### PR DESCRIPTION
ICC C++ compiler icpc takes all defined macros from existing clang, so
__clang__ is defined as well for icpc, yet it does not support #pragma clang.

So prior using #pragma clang we shall check if it is not icpc compiler.

This fixes tens of warnings when using iclc, e.g.:

	lib/catch/include/internal/catch_ptr.hpp(14): warning #161: unrecognized #pragma
	  #pragma clang diagnostic push
	          ^

	In file included from lib/catch/include/internal/catch_context.h(12),
	                 from lib/catch/include/catch.hpp(26),
	                 from src/2d_strip/strip_detector_test.cpp(1):
	lib/catch/include/internal/catch_ptr.hpp(15): warning #161: unrecognized #pragma
	  #pragma clang diagnostic ignored "-Wpadded"
	          ^

	In file included from /Applications/Xcode-Beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/vector(274),
	                 from lib/catch/include/internal/catch_context.h(15),
	                 from lib/catch/include/catch.hpp(26),
	                 from src/2d_strip/strip_detector_test.cpp(1):
	lib/catch/include/internal/catch_ptr.hpp(91): warning #161: unrecognized #pragma
	  #pragma clang diagnostic pop
	          ^

	In file included from lib/catch/include/catch.hpp(39),
	                 from src/2d_strip/strip_detector_test.cpp(1):
	lib/catch/include/internal/catch_test_case_info.h(18): warning #161: unrecognized #pragma
	  #pragma clang diagnostic push
	          ^

	In file included from lib/catch/include/catch.hpp(39),
	                 from src/2d_strip/strip_detector_test.cpp(1):
	lib/catch/include/internal/catch_test_case_info.h(19): warning #161: unrecognized #pragma
	  #pragma clang diagnostic ignored "-Wpadded"
	          ^

	In file included from src/2d_strip/strip_detector_test.cpp(1):
	lib/catch/include/internal/catch_test_case_info.h(87): warning #161: unrecognized #pragma
	  #pragma clang diagnostic pop
	          ^

	In file included from src/2d_strip/strip_detector_test.cpp(5):
	lib/catch/include/internal/catch_reenable_warnings.h(12): warning #161: unrecognized #pragma
	  #pragma clang diagnostic pop
