### PR TITLE
Adds doc on how to make types printable

### DIFF
--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -10,6 +10,7 @@ Before looking at this material be sure to read the [tutorial](tutorial.md)
 * [Build systems](build-systems.md)
 * [Supplying your own main()](own-main.md)
 * [Why are my tests slow to compile?](slow-compiles.md)
+* [Printng arbitrary types](printabletypes.md)
 
 Other
 

--- a/docs/printabletypes.md
+++ b/docs/printabletypes.md
@@ -1,0 +1,40 @@
+# Making Types Printable
+
+Catch is capable of using user defined print functions and overloads.
+
+## Using ostreams
+
+By default, catch will attempt to display types using an ostream overload is available.
+
+```c++
+std::ostream& operator<<(std::ostream&, MySpecialType const&);
+```
+
+## using toString
+If you don't want your type to work with ostreams, or Catch is unable to find the 
+overload you provide, you may alternatively overload `Catch::toString`.  The overload 
+must appear **above** the include of `catch.hpp`.  For example, if I want to provide
+a print functionality for `std::pair<int, char>` in my test, the top of my test file
+would look like this:
+
+```c++
+#include <string>
+#include <sstream>
+#include <utility>
+
+namespace Catch {
+std::string toString(std::pair<int, char> const p) {
+    std::ostringstream oss;
+    oss << '{' << p.first << ", " << p.second << '}';
+    return oss.str();
+}
+}
+
+#include "catch.hpp"
+```
+Note that the former approach is preferred, and the latter is more error-prone
+due to possible typos when typing `Catch` or `toString`
+
+## Default output
+
+If neither of the two conditions has been met, catch will output `{?}` by default.

--- a/docs/printabletypes.md
+++ b/docs/printabletypes.md
@@ -1,16 +1,16 @@
 # Making Types Printable
 
-Catch is capable of using user defined print functions and overloads.
+Catch can print many standard types out of the box, but it is also capable of using user defined print functions and overloads.
 
-## Using ostreams
+## Using ostream and operator<<
 
-By default, catch will attempt to display types using an ostream overload is available.
+By default, catch will attempt to display a variable of type `T` using an ostream overload if available.
 
 ```c++
-std::ostream& operator<<(std::ostream&, MySpecialType const&);
+std::ostream& operator<<(std::ostream&, T const&);
 ```
 
-## using toString
+## Overloading Catch::toString
 If you don't want your type to work with ostreams, or Catch is unable to find the 
 overload you provide, you may alternatively overload `Catch::toString`.  The overload 
 must appear **above** the include of `catch.hpp`.  For example, if I want to provide
@@ -23,7 +23,7 @@ would look like this:
 #include <utility>
 
 namespace Catch {
-std::string toString(std::pair<int, char> const p) {
+std::string toString(std::pair<int, char> const& p) {
     std::ostringstream oss;
     oss << '{' << p.first << ", " << p.second << '}';
     return oss.str();
@@ -37,4 +37,4 @@ due to possible typos when typing `Catch` or `toString`
 
 ## Default output
 
-If neither of the two conditions has been met, catch will output `{?}` by default.
+If neither of the two conditions has been met, and catch does not provide a string conversion for the type, catch will output `{?}` by default.


### PR DESCRIPTION
I spent a little while working my way through the source to find the comments about `toString`.  Overloading this function was the only way I was able to print a `std::pair` without reopening `namespace std`.  It's possible I've missed something, I'll be happy to amend it if you'd like to point me in the right direction.  I just created the document I was looking for before having to dive into the code.