### PR TITLE
(Linux) Support breakpoint upon assertion failure.

### DIFF
--- a/include/internal/catch_debugger.h
+++ b/include/internal/catch_debugger.h
@@ -44,7 +44,7 @@ namespace Catch{
 
 #if defined(__i386__) || defined(__x86_64__)
 #define CATCH_BREAK_INTO_DEBUGGER() \
-    if ( Catch::isDebuggerActive() ) { asm volatile ("int $3"); }
+    if ( Catch::isDebuggerActive() ) { __asm__ __volatile__ ("int $3"); }
 #else // __i386__ || __x86_64__
 #include <signal.h>
 #define CATCH_BREAK_INTO_DEBUGGER() \

--- a/include/internal/catch_debugger.h
+++ b/include/internal/catch_debugger.h
@@ -40,6 +40,17 @@ namespace Catch{
 #elif defined(__MINGW32__)
     extern "C" __declspec(dllimport) void __stdcall DebugBreak();
     #define CATCH_BREAK_INTO_DEBUGGER() if( Catch::isDebuggerActive() ) { DebugBreak(); }
+#elif defined(CATCH_PLATFORM_LINUX)
+
+#if defined(__i386__) || defined(__x86_64__)
+#define CATCH_BREAK_INTO_DEBUGGER() \
+    if ( Catch::isDebuggerActive() ) { asm volatile ("int $3"); }
+#else // __i386__ || __x86_64__
+#include <signal.h>
+#define CATCH_BREAK_INTO_DEBUGGER() \
+    if ( Catch::isDebuggerActive() ) { raise(SIGINT); }
+#endif // __i386__ || __x86_64__
+    
 #endif
 
 #ifndef CATCH_BREAK_INTO_DEBUGGER

--- a/include/internal/catch_debugger.hpp
+++ b/include/internal/catch_debugger.hpp
@@ -75,6 +75,12 @@
             return IsDebuggerPresent() != 0;
         }
     }
+#elif defined(CATCH_PLATFORM_LINUX)
+    namespace Catch {
+        bool isDebuggerActive() {
+            return true;
+        }
+    }
 #else
     namespace Catch {
        inline bool isDebuggerActive() { return false; }

--- a/include/internal/catch_debugger.hpp
+++ b/include/internal/catch_debugger.hpp
@@ -76,9 +76,43 @@
         }
     }
 #elif defined(CATCH_PLATFORM_LINUX)
+
+#include <sys/types.h>
+#include <sys/ptrace.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
     namespace Catch {
         bool isDebuggerActive() {
-            return true;
+            // Based on: http://stackoverflow.com/a/3599394/1281937
+
+            pid_t child_pid = fork();
+
+            if (child_pid == -1)
+                return false;           // Don't know; be pessimistic.
+
+            if (!child_pid) {
+                pid_t parent_pid = getppid();
+                
+                errno = 0;
+                if (ptrace(PTRACE_ATTACH, parent_pid, 0, 0) == -1) {
+                    // We can't attach when there's something already there
+                    // (like a debugger) -- EPERM will indicate.
+                    if (errno == EPERM)
+                        _Exit(1);
+                    _Exit(0);
+                }
+                
+                // A successful attach will stop the parent.
+                waitpid(parent_pid, NULL, 0);
+                ptrace(PTRACE_DETACH, parent_pid, 0, 0);
+                
+                _Exit(0);
+            }
+
+            int result;
+            waitpid(child_pid, &result, 0);
+            return WEXITSTATUS(result)? true: false;
         }
     }
 #else

--- a/include/internal/catch_debugger.hpp
+++ b/include/internal/catch_debugger.hpp
@@ -77,6 +77,7 @@
     }
 #elif defined(CATCH_PLATFORM_LINUX)
 
+#include <errno.h>
 #include <sys/types.h>
 #include <sys/ptrace.h>
 #include <sys/wait.h>

--- a/include/internal/catch_platform.h
+++ b/include/internal/catch_platform.h
@@ -15,6 +15,8 @@
 #define CATCH_PLATFORM_IPHONE
 #elif defined(WIN32) || defined(__WIN32__) || defined(_WIN32) || defined(_MSC_VER)
 #define CATCH_PLATFORM_WINDOWS
+#elif defined(__LINUX__) || defined(__linux__)
+#define CATCH_PLATFORM_LINUX
 #endif
 
 #endif // TWOBLUECUBES_CATCH_PLATFORM_H_INCLUDED


### PR DESCRIPTION
Add CATCH_PLATFORM_LINUX (based on presence of `__LINUX__` or `__linux__`).
For this platform,
- define a conditional check for debugger presence by having a temporary child PTRACE_ATTACH to its parent (failure should indicate a tracer (ie. debugger) is already present). Modified version of [this](http://stackoverflow.com/a/3599394/1281937).
- based on that conditional, upon assertion failure
  - execute a Breakpoint Exception (x86) inline; or
  - raise SIGINT (other architectures; the breakpoint will occur somewhere inside raise()).
