### PR TITLE
Add --force-colour option to force colour output.

### DIFF
--- a/include/internal/catch_commandline.hpp
+++ b/include/internal/catch_commandline.hpp
@@ -170,6 +170,10 @@ namespace Catch {
             .describe( "set a specific seed for random numbers" )
             .bind( &setRngSeed, "'time'|number" );
 
+        cli["--force-colour"]
+            .describe( "force colourised output" )
+            .bind( &ConfigData::forceColour );
+
         return cli;
     }
 

--- a/include/internal/catch_config.hpp
+++ b/include/internal/catch_config.hpp
@@ -37,6 +37,7 @@ namespace Catch {
             noThrow( false ),
             showHelp( false ),
             showInvisibles( false ),
+            forceColour( false ),
             abortAfter( -1 ),
             rngSeed( 0 ),
             verbosity( Verbosity::Normal ),
@@ -55,6 +56,7 @@ namespace Catch {
         bool noThrow;
         bool showHelp;
         bool showInvisibles;
+        bool forceColour;
 
         int abortAfter;
         unsigned int rngSeed;
@@ -131,7 +133,6 @@ namespace Catch {
 
         std::string getReporterName() const { return m_data.reporterName; }
 
-
         int abortAfter() const { return m_data.abortAfter; }
 
         TestSpec const& testSpec() const { return m_testSpec; }
@@ -148,6 +149,7 @@ namespace Catch {
         virtual ShowDurations::OrNot showDurations() const { return m_data.showDurations; }
         virtual RunTests::InWhatOrder runOrder() const  { return m_data.runOrder; }
         virtual unsigned int rngSeed() const    { return m_data.rngSeed; }
+        virtual bool forceColour() const { return m_data.forceColour; }
 
     private:
         ConfigData m_data;

--- a/include/internal/catch_console_colour_impl.hpp
+++ b/include/internal/catch_console_colour_impl.hpp
@@ -143,7 +143,8 @@ namespace {
     };
 
     IColourImpl* platformColourInstance() {
-        return isatty(STDOUT_FILENO)
+        Ptr<IConfig const> config = getCurrentContext().getConfig();
+        return (config && config->forceColour()) || isatty(STDOUT_FILENO)
             ? PosixColourImpl::instance()
             : NoColourImpl::instance();
     }

--- a/include/internal/catch_interfaces_config.h
+++ b/include/internal/catch_interfaces_config.h
@@ -56,6 +56,7 @@ namespace Catch {
         virtual TestSpec const& testSpec() const = 0;
         virtual RunTests::InWhatOrder runOrder() const = 0;
         virtual unsigned int rngSeed() const = 0;
+        virtual bool forceColour() const = 0;
     };
 }
 

--- a/projects/SelfTest/TestMain.cpp
+++ b/projects/SelfTest/TestMain.cpp
@@ -182,7 +182,23 @@ TEST_CASE( "Process can be configured on command line", "[config][command-line]"
             CHECK( config.shouldDebugBreak );
             CHECK( config.noThrow == true );
         }
-    }        
+    }
+
+    SECTION( "force-colour", "") {
+        SECTION( "--force-colour", "" ) {
+            const char* argv[] = { "test", "--force-colour" };
+            CHECK_NOTHROW( parseIntoConfig( argv, config ) );
+
+            REQUIRE( config.forceColour );
+        }
+
+        SECTION( "without --force-colour", "" ) {
+            const char* argv[] = { "test" };
+            CHECK_NOTHROW( parseIntoConfig( argv, config ) );
+
+            REQUIRE( !config.forceColour );
+        }
+    }
 }
 
 


### PR DESCRIPTION
Adding a --force-colour option to force colour output on POSIX systems,
provided a debugger is not attached.

This allows for Catch to output colours even if STDOUT is not a tty,
which can be the case when the test executable is being spawned by a
parent process (e.g. CMake's ctest).