### PR TITLE
Resolved #359, Eclipse will raise false alarm: endExpression cannot be resolved

### DIFF
--- a/include/internal/catch_capture.hpp
+++ b/include/internal/catch_capture.hpp
@@ -33,7 +33,7 @@
     do { \
         Catch::ResultBuilder __catchResult( macroName, CATCH_INTERNAL_LINEINFO, #expr, resultDisposition ); \
         try { \
-            ( __catchResult->*expr ).endExpression(); \
+            __catchResult.eval(expr).endExpression(); \
         } \
         catch( ... ) { \
             __catchResult.useActiveException( Catch::ResultDisposition::Normal ); \

--- a/include/internal/catch_result_builder.h
+++ b/include/internal/catch_result_builder.h
@@ -41,8 +41,8 @@ namespace Catch {
                         ResultDisposition::Flags resultDisposition );
 
         template<typename T>
-        ExpressionLhs<T const&> operator->* ( T const& operand );
-        ExpressionLhs<bool> operator->* ( bool value );
+        ExpressionLhs<T const&> eval( T const& operand );
+        ExpressionLhs<bool> eval( bool value );
 
         template<typename T>
         ResultBuilder& operator << ( T const& value ) {
@@ -93,11 +93,11 @@ namespace Catch {
 namespace Catch {
 
     template<typename T>
-    inline ExpressionLhs<T const&> ResultBuilder::operator->* ( T const& operand ) {
+    inline ExpressionLhs<T const&> ResultBuilder::eval( T const& operand ) {
         return ExpressionLhs<T const&>( *this, operand );
     }
 
-    inline ExpressionLhs<bool> ResultBuilder::operator->* ( bool value ) {
+    inline ExpressionLhs<bool> ResultBuilder::eval( bool value ) {
         return ExpressionLhs<bool>( *this, value );
     }
 

--- a/single_include/catch.hpp
+++ b/single_include/catch.hpp
@@ -724,8 +724,8 @@ namespace Catch {
                         ResultDisposition::Flags resultDisposition );
 
         template<typename T>
-        ExpressionLhs<T const&> operator->* ( T const& operand );
-        ExpressionLhs<bool> operator->* ( bool value );
+        ExpressionLhs<T const&> eval( T const& operand );
+        ExpressionLhs<bool> eval( bool value );
 
         template<typename T>
         ResultBuilder& operator << ( T const& value ) {
@@ -1301,11 +1301,11 @@ private:
 namespace Catch {
 
     template<typename T>
-    inline ExpressionLhs<T const&> ResultBuilder::operator->* ( T const& operand ) {
+    inline ExpressionLhs<T const&> ResultBuilder::eval( T const& operand ) {
         return ExpressionLhs<T const&>( *this, operand );
     }
 
-    inline ExpressionLhs<bool> ResultBuilder::operator->* ( bool value ) {
+    inline ExpressionLhs<bool> ResultBuilder::eval( bool value ) {
         return ExpressionLhs<bool>( *this, value );
     }
 
@@ -1475,7 +1475,7 @@ namespace Catch {
     do { \
         Catch::ResultBuilder __catchResult( macroName, CATCH_INTERNAL_LINEINFO, #expr, resultDisposition ); \
         try { \
-            ( __catchResult->*expr ).endExpression(); \
+            __catchResult.eval(expr).endExpression(); \
         } \
         catch( ... ) { \
             __catchResult.useActiveException( Catch::ResultDisposition::Normal ); \


### PR DESCRIPTION
Eclipse header indexer did not handle the operator->* correctly. So
rename the function from operator->* to eval can resolve the Eclipse
false alert.
Despite the fact that this is the issue of bug by Eclipse, but it is worth to update the code to bypass the annoying false alarm.