### PR TITLE
Resolved #359 - Eclipse CDT - Method 'endExpression' could not be resolved

### DIFF
--- a/include/internal/catch_capture.hpp
+++ b/include/internal/catch_capture.hpp
@@ -33,7 +33,7 @@
     do { \
         Catch::ResultBuilder __catchResult( macroName, CATCH_INTERNAL_LINEINFO, #expr, resultDisposition ); \
         try { \
-            ( __catchResult->*expr ).endExpression(); \
+            ( __catchResult+expr ).endExpression(); \
         } \
         catch( ... ) { \
             __catchResult.useActiveException( Catch::ResultDisposition::Normal ); \

--- a/include/internal/catch_capture.hpp
+++ b/include/internal/catch_capture.hpp
@@ -33,7 +33,7 @@
     do { \
         Catch::ResultBuilder __catchResult( macroName, CATCH_INTERNAL_LINEINFO, #expr, resultDisposition ); \
         try { \
-            ( __catchResult->*expr ).endExpression(); \
+            __catchResult.eval(expr).endExpression(); \
         } \
         catch( ... ) { \
             __catchResult.useActiveException( Catch::ResultDisposition::Normal ); \

--- a/include/internal/catch_capture.hpp
+++ b/include/internal/catch_capture.hpp
@@ -33,7 +33,7 @@
     do { \
         Catch::ResultBuilder __catchResult( macroName, CATCH_INTERNAL_LINEINFO, #expr, resultDisposition ); \
         try { \
-            __catchResult.eval(expr).endExpression(); \
+            ( __catchResult->*expr ).endExpression(); \
         } \
         catch( ... ) { \
             __catchResult.useActiveException( Catch::ResultDisposition::Normal ); \

--- a/include/internal/catch_result_builder.h
+++ b/include/internal/catch_result_builder.h
@@ -41,8 +41,8 @@ namespace Catch {
                         ResultDisposition::Flags resultDisposition );
 
         template<typename T>
-        ExpressionLhs<T const&> operator->* ( T const& operand );
-        ExpressionLhs<bool> operator->* ( bool value );
+        ExpressionLhs<T const&> operator+ ( T const& operand );
+        ExpressionLhs<bool> operator+ ( bool value );
 
         template<typename T>
         ResultBuilder& operator << ( T const& value ) {
@@ -93,11 +93,11 @@ namespace Catch {
 namespace Catch {
 
     template<typename T>
-    inline ExpressionLhs<T const&> ResultBuilder::operator->* ( T const& operand ) {
+    inline ExpressionLhs<T const&> ResultBuilder::operator+ ( T const& operand ) {
         return ExpressionLhs<T const&>( *this, operand );
     }
 
-    inline ExpressionLhs<bool> ResultBuilder::operator->* ( bool value ) {
+    inline ExpressionLhs<bool> ResultBuilder::operator+ ( bool value ) {
         return ExpressionLhs<bool>( *this, value );
     }
 

--- a/include/internal/catch_result_builder.h
+++ b/include/internal/catch_result_builder.h
@@ -41,8 +41,8 @@ namespace Catch {
                         ResultDisposition::Flags resultDisposition );
 
         template<typename T>
-        ExpressionLhs<T const&> eval( T const& operand );
-        ExpressionLhs<bool> eval( bool value );
+        ExpressionLhs<T const&> operator->* ( T const& operand );
+        ExpressionLhs<bool> operator->* ( bool value );
 
         template<typename T>
         ResultBuilder& operator << ( T const& value ) {
@@ -93,11 +93,11 @@ namespace Catch {
 namespace Catch {
 
     template<typename T>
-    inline ExpressionLhs<T const&> ResultBuilder::eval( T const& operand ) {
+    inline ExpressionLhs<T const&> ResultBuilder::operator->* ( T const& operand ) {
         return ExpressionLhs<T const&>( *this, operand );
     }
 
-    inline ExpressionLhs<bool> ResultBuilder::eval( bool value ) {
+    inline ExpressionLhs<bool> ResultBuilder::operator->* ( bool value ) {
         return ExpressionLhs<bool>( *this, value );
     }
 

--- a/include/internal/catch_result_builder.h
+++ b/include/internal/catch_result_builder.h
@@ -41,8 +41,8 @@ namespace Catch {
                         ResultDisposition::Flags resultDisposition );
 
         template<typename T>
-        ExpressionLhs<T const&> operator->* ( T const& operand );
-        ExpressionLhs<bool> operator->* ( bool value );
+        ExpressionLhs<T const&> eval( T const& operand );
+        ExpressionLhs<bool> eval( bool value );
 
         template<typename T>
         ResultBuilder& operator << ( T const& value ) {
@@ -93,11 +93,11 @@ namespace Catch {
 namespace Catch {
 
     template<typename T>
-    inline ExpressionLhs<T const&> ResultBuilder::operator->* ( T const& operand ) {
+    inline ExpressionLhs<T const&> ResultBuilder::eval( T const& operand ) {
         return ExpressionLhs<T const&>( *this, operand );
     }
 
-    inline ExpressionLhs<bool> ResultBuilder::operator->* ( bool value ) {
+    inline ExpressionLhs<bool> ResultBuilder::eval( bool value ) {
         return ExpressionLhs<bool>( *this, value );
     }
 

--- a/single_include/catch.hpp
+++ b/single_include/catch.hpp
@@ -724,8 +724,8 @@ namespace Catch {
                         ResultDisposition::Flags resultDisposition );
 
         template<typename T>
-        ExpressionLhs<T const&> operator->* ( T const& operand );
-        ExpressionLhs<bool> operator->* ( bool value );
+        ExpressionLhs<T const&> operator+ ( T const& operand );
+        ExpressionLhs<bool> operator+ ( bool value );
 
         template<typename T>
         ResultBuilder& operator << ( T const& value ) {
@@ -1301,11 +1301,11 @@ private:
 namespace Catch {
 
     template<typename T>
-    inline ExpressionLhs<T const&> ResultBuilder::operator->* ( T const& operand ) {
+    inline ExpressionLhs<T const&> ResultBuilder::operator+ ( T const& operand ) {
         return ExpressionLhs<T const&>( *this, operand );
     }
 
-    inline ExpressionLhs<bool> ResultBuilder::operator->* ( bool value ) {
+    inline ExpressionLhs<bool> ResultBuilder::operator+ ( bool value ) {
         return ExpressionLhs<bool>( *this, value );
     }
 
@@ -1475,7 +1475,7 @@ namespace Catch {
     do { \
         Catch::ResultBuilder __catchResult( macroName, CATCH_INTERNAL_LINEINFO, #expr, resultDisposition ); \
         try { \
-            ( __catchResult->*expr ).endExpression(); \
+            ( __catchResult+expr ).endExpression(); \
         } \
         catch( ... ) { \
             __catchResult.useActiveException( Catch::ResultDisposition::Normal ); \

--- a/single_include/catch.hpp
+++ b/single_include/catch.hpp
@@ -724,8 +724,8 @@ namespace Catch {
                         ResultDisposition::Flags resultDisposition );
 
         template<typename T>
-        ExpressionLhs<T const&> operator->* ( T const& operand );
-        ExpressionLhs<bool> operator->* ( bool value );
+        ExpressionLhs<T const&> eval( T const& operand );
+        ExpressionLhs<bool> eval( bool value );
 
         template<typename T>
         ResultBuilder& operator << ( T const& value ) {
@@ -1301,11 +1301,11 @@ private:
 namespace Catch {
 
     template<typename T>
-    inline ExpressionLhs<T const&> ResultBuilder::operator->* ( T const& operand ) {
+    inline ExpressionLhs<T const&> ResultBuilder::eval( T const& operand ) {
         return ExpressionLhs<T const&>( *this, operand );
     }
 
-    inline ExpressionLhs<bool> ResultBuilder::operator->* ( bool value ) {
+    inline ExpressionLhs<bool> ResultBuilder::eval( bool value ) {
         return ExpressionLhs<bool>( *this, value );
     }
 
@@ -1475,7 +1475,7 @@ namespace Catch {
     do { \
         Catch::ResultBuilder __catchResult( macroName, CATCH_INTERNAL_LINEINFO, #expr, resultDisposition ); \
         try { \
-            ( __catchResult->*expr ).endExpression(); \
+            __catchResult.eval(expr).endExpression(); \
         } \
         catch( ... ) { \
             __catchResult.useActiveException( Catch::ResultDisposition::Normal ); \

--- a/single_include/catch.hpp
+++ b/single_include/catch.hpp
@@ -724,8 +724,8 @@ namespace Catch {
                         ResultDisposition::Flags resultDisposition );
 
         template<typename T>
-        ExpressionLhs<T const&> eval( T const& operand );
-        ExpressionLhs<bool> eval( bool value );
+        ExpressionLhs<T const&> operator->* ( T const& operand );
+        ExpressionLhs<bool> operator->* ( bool value );
 
         template<typename T>
         ResultBuilder& operator << ( T const& value ) {
@@ -1301,11 +1301,11 @@ private:
 namespace Catch {
 
     template<typename T>
-    inline ExpressionLhs<T const&> ResultBuilder::eval( T const& operand ) {
+    inline ExpressionLhs<T const&> ResultBuilder::operator->* ( T const& operand ) {
         return ExpressionLhs<T const&>( *this, operand );
     }
 
-    inline ExpressionLhs<bool> ResultBuilder::eval( bool value ) {
+    inline ExpressionLhs<bool> ResultBuilder::operator->* ( bool value ) {
         return ExpressionLhs<bool>( *this, value );
     }
 
@@ -1475,7 +1475,7 @@ namespace Catch {
     do { \
         Catch::ResultBuilder __catchResult( macroName, CATCH_INTERNAL_LINEINFO, #expr, resultDisposition ); \
         try { \
-            __catchResult.eval(expr).endExpression(); \
+            ( __catchResult->*expr ).endExpression(); \
         } \
         catch( ... ) { \
             __catchResult.useActiveException( Catch::ResultDisposition::Normal ); \


### PR DESCRIPTION
Eclipse indexer did not handle the ->* operator correctly and display error in the editor, whereas it actually is not a bug. Changing the operator from operator->* to operator+ can resolve this problem.

Proof of concept:
Priority 3   operator+       Right-to-left
Priority 4   operator->*     Left-to-right

where:
__catchResult+expr

Supported operator in expr:
Prority 3   +
Prority 3   -
Priority 3   /
Priority 3   *
Priority 13   &&  *STATIC_ASSERT_Expression_Too_Complex_Please_Rewrite_As_Binary_Comparison
Priority 14   ||  *STATIC_ASSERT_Expression_Too_Complex_Please_Rewrite_As_Binary_Comparison

   __catchResult + _1Obj   operand1 _2Obj .... _NObj
=> (__catchResult + _1Obj) operand1 _2Obj .... _NObj
=> ExpressionLhs<T>        operand1 _2Obj .... _NObj
Hence, the change is OK
