### PR TITLE
Added FAIL_AT, MARK_FAILED and MARK_FAILED_AT

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -26,6 +26,18 @@ The message is always reported but does not fail the test.
 
 The message is reported and the test case fails.
 
+**FAIL_AT(** _file_, _line_, _message expression_ **)**
+
+Used when binding other test frameworks to report errors through Catch. Same as **FAIL(** _message expression_ **)** above, but _file_ and _line_ is a reference to the location in the source code the failure will be reported at.
+
+**MARK_FAILED(** _message expression_ **)**
+
+The message is reported and the test case fails, but execution continues.
+
+**MARK_FAILED_AT(** _file_, _line_, _message expression_ **)**
+
+Used when binding othet test frameworks to report errots through Catch. Same as **MARK_FAILED(** _message expression_ **)** above, but _file_ and _line_ is a reference to the location in the source code the failure will be reported at.
+
 ## Quickly capture a variable value
 
 **CAPTURE(** _expression_ **)**

--- a/include/catch.hpp
+++ b/include/catch.hpp
@@ -93,6 +93,9 @@
     #define CATCH_METHOD_AS_TEST_CASE( method, ... ) INTERNAL_CATCH_METHOD_AS_TEST_CASE( method, __VA_ARGS__ )
     #define CATCH_SECTION( ... ) INTERNAL_CATCH_SECTION( __VA_ARGS__ )
     #define CATCH_FAIL( ... ) INTERNAL_CATCH_MSG( Catch::ResultWas::ExplicitFailure, Catch::ResultDisposition::Normal, "CATCH_FAIL", __VA_ARGS__ )
+    #define CATCH_FAIL_AT( file, line, ... ) INTERNAL_CATCH_MSG_AT( Catch::ResultWas::ExplicitFailure, Catch::ResultDisposition::Normal, "CATCH_FAIL", Catch::SourceLineInfo( file, line ),  __VA_ARGS__ )
+    #define CATCH_MARK_FAILED( ... ) INTERNAL_CATCH_MSG( Catch::ResultWas::ExplicitFailure, Catch::ResultDisposition::ContinueOnFailure, "CATCH_MARK_FAILED", __VA_ARGS__ )
+    #define CATCH_MARK_FAILED_AT( file, line,  ... ) INTERNAL_CATCH_MSG_AT( Catch::ResultWas::ExplicitFailure, Catch::ResultDisposition::ContinueOnFailure, "CATCH_MARK_FAILED", Catch::SourceLineInfo( file, line ), __VA_ARGS__ )
     #define CATCH_SUCCEED( ... ) INTERNAL_CATCH_MSG( Catch::ResultWas::Ok, Catch::ResultDisposition::ContinueOnFailure, "CATCH_SUCCEED", __VA_ARGS__ )
 #else
     #define CATCH_TEST_CASE( name, description ) INTERNAL_CATCH_TESTCASE( name, description )
@@ -100,6 +103,9 @@
     #define CATCH_METHOD_AS_TEST_CASE( method, name, description ) INTERNAL_CATCH_METHOD_AS_TEST_CASE( method, name, description )
     #define CATCH_SECTION( name, description ) INTERNAL_CATCH_SECTION( name, description )
     #define CATCH_FAIL( msg ) INTERNAL_CATCH_MSG( Catch::ResultWas::ExplicitFailure, Catch::ResultDisposition::Normal, "CATCH_FAIL", msg )
+    #define CATCH_FAIL_AT( file, line, msg ) INTERNAL_CATCH_MSG_AT( Catch::ResultWas::ExplicitFailure, Catch::ResultDisposition::Normal, "CATCH_FAIL", Catch::SourceLineInfo( file, line ), msg )
+    #define CATCH_MARK_FAILED( msg ) INTERNAL_CATCH_MSG( Catch::ResultWas::ExplicitFailure, Catch::ResultDisposition::ContinueOnFailure, "CATCH_MARK_FAILED", msg )
+    #define CATCH_MARK_FAILED_AT( file, line, msg ) INTERNAL_CATCH_MSG_AT( Catch::ResultWas::ExplicitFailure, Catch::ResultDisposition::ContinueOnFailure, "CATCH_MARK_FAILED", Catch::SourceLineInfo( file, line ), msg )
     #define CATCH_SUCCEED( msg ) INTERNAL_CATCH_MSG( Catch::ResultWas::Ok, Catch::ResultDisposition::ContinueOnFailure, "CATCH_SUCCEED", msg )
 #endif
 #define CATCH_ANON_TEST_CASE() INTERNAL_CATCH_TESTCASE( "", "" )
@@ -158,6 +164,9 @@
     #define METHOD_AS_TEST_CASE( method, ... ) INTERNAL_CATCH_METHOD_AS_TEST_CASE( method, __VA_ARGS__ )
     #define SECTION( ... ) INTERNAL_CATCH_SECTION( __VA_ARGS__ )
     #define FAIL( ... ) INTERNAL_CATCH_MSG( Catch::ResultWas::ExplicitFailure, Catch::ResultDisposition::Normal, "FAIL", __VA_ARGS__ )
+    #define FAIL_AT( file, line, ... ) INTERNAL_CATCH_MSG_AT( Catch::ResultWas::ExplicitFailure, Catch::ResultDisposition::Normal, "FAIL", Catch::SourceLineInfo( file, line ), __VA_ARGS__ )
+    #define MARK_FAILED( ... ) INTERNAL_CATCH_MSG( Catch::ResultWas::ExplicitFailure, Catch::ResultDisposition::ContinueOnFailure, "MARK_FAILED", __VA_ARGS__ )
+    #define MARK_FAILED_AT( file, line, ... ) INTERNAL_CATCH_MSG_AT( Catch::ResultWas::ExplicitFailure, Catch::ResultDisposition::ContinueOnFailure, "MARK_FAILED", Catch::SourceLineInfo( file, line ), __VA_ARGS__ )
     #define SUCCEED( ... ) INTERNAL_CATCH_MSG( Catch::ResultWas::Ok, Catch::ResultDisposition::ContinueOnFailure, "SUCCEED", __VA_ARGS__ )
 #else
     #define TEST_CASE( name, description ) INTERNAL_CATCH_TESTCASE( name, description )
@@ -165,6 +174,9 @@
     #define METHOD_AS_TEST_CASE( method, name, description ) INTERNAL_CATCH_METHOD_AS_TEST_CASE( method, name, description )
     #define SECTION( name, description ) INTERNAL_CATCH_SECTION( name, description )
     #define FAIL( msg ) INTERNAL_CATCH_MSG( Catch::ResultWas::ExplicitFailure, Catch::ResultDisposition::Normal, "FAIL", msg )
+    #define MARK_FAILED( msg ) INTERNAL_CATCH_MSG( Catch::ResultWas::ExplicitFailure, Catch::ResultDisposition::ContinueOnFailure, "MARK_FAILED", msg )
+#define FAIL_AT( file, line, msg ) INTERNAL_CATCH_MSG_AT( Catch::ResultWas::ExplicitFailure, Catch::ResultDisposition::Normal, "FAIL", Catch::SourceLineInfo( file, line ), msg )
+    #define MARK_FAILED_AT( file, line, msg ) INTERNAL_CATCH_MSG_AT( Catch::ResultWas::ExplicitFailure, Catch::ResultDisposition::ContinueOnFailure, "MARK_FAILED", Catch::SourceLineINfo( file, line ), msg )
     #define SUCCEED( msg ) INTERNAL_CATCH_MSG( Catch::ResultWas::Ok, Catch::ResultDisposition::ContinueOnFailure, "SUCCEED", msg )
 #endif
 #define ANON_TEST_CASE() INTERNAL_CATCH_TESTCASE( "", "" )

--- a/include/internal/catch_capture.hpp
+++ b/include/internal/catch_capture.hpp
@@ -123,7 +123,26 @@
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
-#define INTERNAL_CATCH_INFO( log, macroName ) \
+#ifdef CATCH_CONFIG_VARIADIC_MACROS
+    #define INTERNAL_CATCH_MSG_AT( messageType, resultDisposition, macroName, location, ... ) \
+        do { \
+            Catch::ResultBuilder __catchResult( macroName, location, "", resultDisposition ); \
+            __catchResult << __VA_ARGS__ + ::Catch::StreamEndStop(); \
+            __catchResult.captureResult( messageType ); \
+            INTERNAL_CATCH_REACT( __catchResult ) \
+        } while( Catch::alwaysFalse() )
+#else
+    #define INTERNAL_CATCH_MSG_AT( messageType, resultDisposition, macroName, location, locationlog ) \
+        do { \
+            Catch::ResultBuilder __catchResult( macroName, location, "", resultDisposition ); \
+            __catchResult << log + ::Catch::StreamEndStop(); \
+            __catchResult.captureResult( messageType ); \
+            INTERNAL_CATCH_REACT( __catchResult ) \
+        } while( Catch::alwaysFalse() )
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+#define INTERNAL_CATCH_INFO( log, macroName )                           \
     Catch::ScopedMessage INTERNAL_CATCH_UNIQUE_NAME( scopedMessage ) = Catch::MessageBuilder( macroName, CATCH_INTERNAL_LINEINFO, Catch::ResultWas::Info ) << log;
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/projects/SelfTest/MessageTests.cpp
+++ b/projects/SelfTest/MessageTests.cpp
@@ -55,11 +55,41 @@ TEST_CASE( "FAIL aborts the test", "[failing][messages][.]" )
     FAIL( "This is a " << "failure" );    // This should output the message and abort
 }
 
+TEST_CASE( "reportFailure Normal aborts the test", "[reportFailure][failing][messages][.]" )
+{
+    FAIL_AT("MessageTests.cpp", 1U, "This is a " << "failure"); // This should output the message and abort
+}
+
+TEST_CASE( "MARK_FAILED fails the test", "[failing][messages][.]" )
+{
+    MARK_FAILED( "This is a " << "failure" );
+}
+
+TEST_CASE( "MARK_FAILED_AT fails the test", "[failing][messages][.]" )
+{
+    MARK_FAILED_AT("MessageTests.cpp", 0U, "This is a " << "failure");
+}
+
 #ifdef CATCH_CONFIG_VARIADIC_MACROS
 TEST_CASE( "FAIL does not require an argument", "[failing][messages][.]" )
 {
     FAIL();
 }
+
+TEST_CASE( "FAIL_AT does not require an argument", "[failing][messages][.]" )
+{
+    FAIL_AT("MessageTests.cpp", 10U);
+}
+TEST_CASE( "MARK_FAILED does not require an argument", "[failing][messages][.]" )
+{
+    MARK_FAILED();
+}
+
+TEST_CASE( "MARK_FAILED_AT does not require an argument", "[failing][messages][.]" )
+{
+    MARK_FAILED_AT("MessageTests.cpp", 0U);
+}
+
 TEST_CASE( "SUCCESS does not require an argument", "[messages][.]" )
 {
    SUCCEED();


### PR DESCRIPTION
I went back and forth between alternatives several times, but in the end I decided on going the macro way instead of exposing a generic report() function. The latter would expose internal data types, making Catch implementation more rigid. This solution is also more in line with what you find in other frame works like google-test and boost unit test.

I hope I've not butchered things too badly. I tried to stay true to your coding style.