### PR TITLE
Fix -Wshadow warnings with GCC.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![catch logo](catch-logo-small.png)
 
-*v1.1 build 3 (master branch)*
+*v1.1 build 4 (master branch)*
 
 Build status (on Travis CI) [![Build Status](https://travis-ci.org/philsquared/Catch.png)](https://travis-ci.org/philsquared/Catch)
 

--- a/include/external/clara.h
+++ b/include/external/clara.h
@@ -585,8 +585,8 @@ namespace Clara {
                 m_arg->description = description;
                 return *this;
             }
-            ArgBuilder& detail( std::string const& detail ) {
-                m_arg->detail = detail;
+            ArgBuilder& detail( std::string const& d ) {
+                m_arg->detail = d;
                 return *this;
             }
 
@@ -670,14 +670,14 @@ namespace Clara {
                 maxWidth = (std::max)( maxWidth, it->commands().size() );
 
             for( it = itBegin; it != itEnd; ++it ) {
-                Detail::Text usage( it->commands(), Detail::TextAttributes()
+                Detail::Text usageText( it->commands(), Detail::TextAttributes()
                                                         .setWidth( maxWidth+indent )
                                                         .setIndent( indent ) );
                 Detail::Text desc( it->description, Detail::TextAttributes()
                                                         .setWidth( width - maxWidth - 3 ) );
 
-                for( std::size_t i = 0; i < (std::max)( usage.size(), desc.size() ); ++i ) {
-                    std::string usageCol = i < usage.size() ? usage[i] : "";
+                for( std::size_t i = 0; i < (std::max)( usageText.size(), desc.size() ); ++i ) {
+                    std::string usageCol = i < usageText.size() ? usageText[i] : "";
                     os << usageCol;
 
                     if( i < desc.size() && !desc[i].empty() )

--- a/include/internal/catch_config.hpp
+++ b/include/internal/catch_config.hpp
@@ -125,10 +125,10 @@ namespace Catch {
         }
 
         void useStream( std::string const& streamName ) {
-            Stream stream = createStream( streamName );
-            setStreamBuf( stream.streamBuf );
+            Stream newStream = createStream( streamName );
+            setStreamBuf( newStream.streamBuf );
             m_stream.release();
-            m_stream = stream;
+            m_stream = newStream;
         }
 
         std::string getReporterName() const { return m_data.reporterName; }

--- a/include/internal/catch_runner_impl.hpp
+++ b/include/internal/catch_runner_impl.hpp
@@ -59,11 +59,11 @@ namespace Catch {
 
     public:
 
-        explicit RunContext( Ptr<IConfig const> const& config, Ptr<IStreamingReporter> const& reporter )
-        :   m_runInfo( config->name() ),
+        explicit RunContext( Ptr<IConfig const> const& cfg, Ptr<IStreamingReporter> const& reporter )
+        :   m_runInfo( cfg->name() ),
             m_context( getCurrentMutableContext() ),
             m_activeTestCase( NULL ),
-            m_config( config ),
+            m_config( cfg ),
             m_reporter( reporter ),
             m_prevRunner( m_context.getRunner() ),
             m_prevResultCapture( m_context.getResultCapture() ),

--- a/include/internal/catch_version.hpp
+++ b/include/internal/catch_version.hpp
@@ -13,7 +13,7 @@
 namespace Catch {
 
     // These numbers are maintained by a script
-    Version libraryVersion( 1, 1, 3, "master" );
+    Version libraryVersion( 1, 1, 4, "master" );
 }
 
 #endif // TWOBLUECUBES_CATCH_VERSION_HPP_INCLUDED

--- a/single_include/catch.hpp
+++ b/single_include/catch.hpp
@@ -1,6 +1,6 @@
 /*
- *  CATCH v1.1 build 3 (master branch)
- *  Generated: 2015-05-21 06:16:00.388118
+ *  CATCH v1.1 build 4 (master branch)
+ *  Generated: 2015-05-24 13:31:34.884512
  *  ----------------------------------------------------------
  *  This file has been merged from multiple headers. Please don't edit it directly
  *  Copyright (c) 2012 Two Blue Cubes Ltd. All rights reserved.
@@ -3284,10 +3284,10 @@ namespace Catch {
         }
 
         void useStream( std::string const& streamName ) {
-            Stream stream = createStream( streamName );
-            setStreamBuf( stream.streamBuf );
+            Stream newStream = createStream( streamName );
+            setStreamBuf( newStream.streamBuf );
             m_stream.release();
-            m_stream = stream;
+            m_stream = newStream;
         }
 
         std::string getReporterName() const { return m_data.reporterName; }
@@ -3902,8 +3902,8 @@ namespace Clara {
                 m_arg->description = description;
                 return *this;
             }
-            ArgBuilder& detail( std::string const& detail ) {
-                m_arg->detail = detail;
+            ArgBuilder& detail( std::string const& d ) {
+                m_arg->detail = d;
                 return *this;
             }
 
@@ -3986,14 +3986,14 @@ namespace Clara {
                 maxWidth = (std::max)( maxWidth, it->commands().size() );
 
             for( it = itBegin; it != itEnd; ++it ) {
-                Detail::Text usage( it->commands(), Detail::TextAttributes()
+                Detail::Text usageText( it->commands(), Detail::TextAttributes()
                                                         .setWidth( maxWidth+indent )
                                                         .setIndent( indent ) );
                 Detail::Text desc( it->description, Detail::TextAttributes()
                                                         .setWidth( width - maxWidth - 3 ) );
 
-                for( std::size_t i = 0; i < (std::max)( usage.size(), desc.size() ); ++i ) {
-                    std::string usageCol = i < usage.size() ? usage[i] : "";
+                for( std::size_t i = 0; i < (std::max)( usageText.size(), desc.size() ); ++i ) {
+                    std::string usageCol = i < usageText.size() ? usageText[i] : "";
                     os << usageCol;
 
                     if( i < desc.size() && !desc[i].empty() )
@@ -5235,11 +5235,11 @@ namespace Catch {
 
     public:
 
-        explicit RunContext( Ptr<IConfig const> const& config, Ptr<IStreamingReporter> const& reporter )
-        :   m_runInfo( config->name() ),
+        explicit RunContext( Ptr<IConfig const> const& cfg, Ptr<IStreamingReporter> const& reporter )
+        :   m_runInfo( cfg->name() ),
             m_context( getCurrentMutableContext() ),
             m_activeTestCase( NULL ),
-            m_config( config ),
+            m_config( cfg ),
             m_reporter( reporter ),
             m_prevRunner( m_context.getRunner() ),
             m_prevResultCapture( m_context.getResultCapture() ),
@@ -6807,7 +6807,7 @@ namespace Catch {
 namespace Catch {
 
     // These numbers are maintained by a script
-    Version libraryVersion( 1, 1, 3, "master" );
+    Version libraryVersion( 1, 1, 4, "master" );
 }
 
 // #included from: catch_message.hpp


### PR DESCRIPTION
This patch fixes `-Wshadow` warnings that I see when I use Catch in log4cplus.