### PR TITLE
Fixed "char * const" versus "const char *" confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![catch logo](catch-logo-small.png)
 
-*v1.1 build 3 (master branch)*
+*v1.1 build 4 (master branch)*
 
 Build status (on Travis CI) [![Build Status](https://travis-ci.org/philsquared/Catch.png)](https://travis-ci.org/philsquared/Catch)
 

--- a/docs/own-main.md
+++ b/docs/own-main.md
@@ -16,7 +16,7 @@ If you just need to have code that executes before and/ or after Catch this is t
 #define CATCH_CONFIG_RUNNER
 #include "catch.hpp"
 
-int main( int argc, char* const argv[] )
+int main( int argc, char const * argv[] )
 {
   // global setup...
 
@@ -36,7 +36,7 @@ If you still want Catch to process the command line, but you want to programatic
 #define CATCH_CONFIG_RUNNER
 #include "catch.hpp"
 
-int main( int argc, char* const argv[] )
+int main( int argc, char const * argv[] )
 {
   Catch::Session session; // There must be exactly once instance
 

--- a/include/catch_runner.hpp
+++ b/include/catch_runner.hpp
@@ -137,7 +137,7 @@ namespace Catch {
             Catch::cout() << "For more detail usage please see the project docs\n" << std::endl;
         }
 
-        int applyCommandLine( int argc, char* const argv[], OnUnusedOptions::DoWhat unusedOptionBehaviour = OnUnusedOptions::Fail ) {
+        int applyCommandLine( int argc, char const * argv[], OnUnusedOptions::DoWhat unusedOptionBehaviour = OnUnusedOptions::Fail ) {
             try {
                 m_cli.setThrowOnUnrecognisedTokens( unusedOptionBehaviour == OnUnusedOptions::Fail );
                 m_unusedTokens = m_cli.parseInto( argc, argv, m_configData );
@@ -163,7 +163,7 @@ namespace Catch {
             m_config.reset();
         }
 
-        int run( int argc, char* const argv[] ) {
+        int run( int argc, char const * argv[] ) {
 
             int returnCode = applyCommandLine( argc, argv );
             if( returnCode == 0 )

--- a/include/internal/catch_default_main.hpp
+++ b/include/internal/catch_default_main.hpp
@@ -11,20 +11,20 @@
 #ifndef __OBJC__
 
 // Standard C/C++ main entry point
-int main (int argc, char * const argv[]) {
+int main (int argc, char const * argv[]) {
     return Catch::Session().run( argc, argv );
 }
 
 #else // __OBJC__
 
 // Objective-C entry point
-int main (int argc, char * const argv[]) {
+int main (int argc, char const * argv[]) {
 #if !CATCH_ARC_ENABLED
     NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
 #endif
 
     Catch::registerTestMethods();
-    int result = Catch::Session().run( argc, (char* const*)argv );
+    int result = Catch::Session().run( argc, argv );
 
 #if !CATCH_ARC_ENABLED
     [pool drain];

--- a/include/internal/catch_version.hpp
+++ b/include/internal/catch_version.hpp
@@ -13,7 +13,7 @@
 namespace Catch {
 
     // These numbers are maintained by a script
-    Version libraryVersion( 1, 1, 3, "master" );
+    Version libraryVersion( 1, 1, 4, "master" );
 }
 
 #endif // TWOBLUECUBES_CATCH_VERSION_HPP_INCLUDED

--- a/single_include/catch.hpp
+++ b/single_include/catch.hpp
@@ -1,6 +1,6 @@
 /*
- *  CATCH v1.1 build 3 (master branch)
- *  Generated: 2015-05-21 06:16:00.388118
+ *  CATCH v1.1 build 4 (master branch)
+ *  Generated: 2015-05-27 20:46:59.941284
  *  ----------------------------------------------------------
  *  This file has been merged from multiple headers. Please don't edit it directly
  *  Copyright (c) 2012 Two Blue Cubes Ltd. All rights reserved.
@@ -5681,7 +5681,7 @@ namespace Catch {
             Catch::cout() << "For more detail usage please see the project docs\n" << std::endl;
         }
 
-        int applyCommandLine( int argc, char* const argv[], OnUnusedOptions::DoWhat unusedOptionBehaviour = OnUnusedOptions::Fail ) {
+        int applyCommandLine( int argc, char const * argv[], OnUnusedOptions::DoWhat unusedOptionBehaviour = OnUnusedOptions::Fail ) {
             try {
                 m_cli.setThrowOnUnrecognisedTokens( unusedOptionBehaviour == OnUnusedOptions::Fail );
                 m_unusedTokens = m_cli.parseInto( argc, argv, m_configData );
@@ -5707,7 +5707,7 @@ namespace Catch {
             m_config.reset();
         }
 
-        int run( int argc, char* const argv[] ) {
+        int run( int argc, char const * argv[] ) {
 
             int returnCode = applyCommandLine( argc, argv );
             if( returnCode == 0 )
@@ -6807,7 +6807,7 @@ namespace Catch {
 namespace Catch {
 
     // These numbers are maintained by a script
-    Version libraryVersion( 1, 1, 3, "master" );
+    Version libraryVersion( 1, 1, 4, "master" );
 }
 
 // #included from: catch_message.hpp
@@ -9274,20 +9274,20 @@ namespace Catch {
 #ifndef __OBJC__
 
 // Standard C/C++ main entry point
-int main (int argc, char * const argv[]) {
+int main (int argc, char const * argv[]) {
     return Catch::Session().run( argc, argv );
 }
 
 #else // __OBJC__
 
 // Objective-C entry point
-int main (int argc, char * const argv[]) {
+int main (int argc, char const * argv[]) {
 #if !CATCH_ARC_ENABLED
     NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
 #endif
 
     Catch::registerTestMethods();
-    int result = Catch::Session().run( argc, (char* const*)argv );
+    int result = Catch::Session().run( argc, argv );
 
 #if !CATCH_ARC_ENABLED
     [pool drain];


### PR DESCRIPTION
There are some confusions between `char const  *` (pointer to a constant char, equivalent to `const char *`) and `char * const` (the pointer is constant, but the char is mutable) throughout the code base. This introduces some unnecessary castings and complicates the manual use of `Catch::Session().run(argc, argv)` when using some very common definitions of `main()` or arrays of string literals. Below are a couple of examples that fail to build with the current master branch.

Example 1:

```
#define CONFIG_CATCH_RUNNER
#include "catch.hpp"

int main(int argc, const char **argv)
{
  Catch::Session().run(argc, argv);
  return 0;
}
```

Example 2:

```
#define CONFIG_CATCH_RUNNER
#include "catch.hpp"

int main()
{
  const char *argv[] = { "my_tests", 0 };
  Catch::Session().run(1, argv);
  return 0;
}
```

NOTE: In this pull request I have already rebuilt the single header with the script. I am not sure if I had to do anything else (or if I should not have done this).
