### PR TITLE
defines BDD acronym, and replaces TDD with BDD

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -13,7 +13,7 @@ The rest of this tutorial will assume that the Catch single-include header (or t
 
 # Writing tests
 
-Let's start with a really simple example. Say you have written a function to calculate factorials and now you want to test it (let's leave aside TDD for now). 
+Let's start with a really simple example. Say you have written a function to calculate factorials and now you want to test it (let's leave aside BDD for now). 
 
 ```c++
 unsigned int Factorial( unsigned int number ) {
@@ -159,7 +159,7 @@ The power of sections really shows, however, when we need to execute a sequence 
 
 Sections can be nested to an arbitrary depth (limited only by your stack size). Each leaf section (i.e. a section that contains no nested sections) will be executed exactly once, on a separate path of execution from any other leaf section (so no leaf section can interfere with another). A failure in a parent section will prevent nested sections from running - but then that's the idea.
 
-## BDD-Style
+## BDD-Style  (Behaviour Driven Development)
 
 If you name your test cases and sections appropriately you can achieve a BDD-style specification structure. This became such a useful way of working that first class support has been added to Catch. Scenarios can be specified using ```SCENARIO```, ```GIVEN```, ```WHEN``` and ```THEN``` macros, which map on to ```TEST_CASE```s and ```SECTION```s, respectively. For more details see [Test cases and sections](test-cases-and-sections.md).
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -159,7 +159,7 @@ The power of sections really shows, however, when we need to execute a sequence 
 
 Sections can be nested to an arbitrary depth (limited only by your stack size). Each leaf section (i.e. a section that contains no nested sections) will be executed exactly once, on a separate path of execution from any other leaf section (so no leaf section can interfere with another). A failure in a parent section will prevent nested sections from running - but then that's the idea.
 
-## BDD-Style  (Behaviour Driven Development)
+## BDD-Style (Behaviour Driven Development)  
 
 If you name your test cases and sections appropriately you can achieve a BDD-style specification structure. This became such a useful way of working that first class support has been added to Catch. Scenarios can be specified using ```SCENARIO```, ```GIVEN```, ```WHEN``` and ```THEN``` macros, which map on to ```TEST_CASE```s and ```SECTION```s, respectively. For more details see [Test cases and sections](test-cases-and-sections.md).
 


### PR DESCRIPTION
I think BDD was meant instead of TDD.  I don't see anything about Test-Driven Development further down the documentation.  
Also, the acronym BDD might be obvious to some, but I had to look it up while reading.