### PR TITLE
Fixed code analysis warning C28251.

### DIFF
--- a/include/internal/catch_debugger.hpp
+++ b/include/internal/catch_debugger.hpp
@@ -82,7 +82,7 @@
 #endif // Platform
 
 #ifdef CATCH_PLATFORM_WINDOWS
-    extern "C" __declspec(dllimport) void __stdcall OutputDebugStringA( const char* );
+    extern "C" __declspec(dllimport) void __stdcall OutputDebugStringA( _In_opt_ const char* );
     namespace Catch {
         void writeToDebugConsole( std::string const& text ) {
             ::OutputDebugStringA( text.c_str() );


### PR DESCRIPTION
Fix for C28251 "Inconsistent annotation for function: this instance has an error":

Inconsistent annotation for `OutputDebugStringA`: this instance has no annotations. See `c:\program files (x86)\windows kits\8.1\include\um\debugapi.h(85)`. `catch_debugger.hpp`	85