### PR TITLE
Detect nullptr support in GCC 5 better

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![catch logo](catch-logo-small.png)
 
-*v1.2.1-develop.6*
+*v1.2.1-develop.7*
 
 Build status (on Travis CI) [![Build Status](https://travis-ci.org/philsquared/Catch.png)](https://travis-ci.org/philsquared/Catch)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![catch logo](catch-logo-small.png)
 
-*v1.2.1-develop.4*
+*v1.2.1-develop.5*
 
 Build status (on Travis CI) [![Build Status](https://travis-ci.org/philsquared/Catch.png)](https://travis-ci.org/philsquared/Catch)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![catch logo](catch-logo-small.png)
 
-*v1.2.1-develop.1*
+*v1.2.1-develop.2*
 
 Build status (on Travis CI) [![Build Status](https://travis-ci.org/philsquared/Catch.png)](https://travis-ci.org/philsquared/Catch)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![catch logo](catch-logo-small.png)
 
-*v1.2.0*
+*v1.2.1*
 
 Build status (on Travis CI) [![Build Status](https://travis-ci.org/philsquared/Catch.png)](https://travis-ci.org/philsquared/Catch)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![catch logo](catch-logo-small.png)
 
-*v1.2.1-develop.7*
+*v1.2.1-develop.8*
 
 Build status (on Travis CI) [![Build Status](https://travis-ci.org/philsquared/Catch.png)](https://travis-ci.org/philsquared/Catch)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![catch logo](catch-logo-small.png)
 
-*v1.2.1-develop.9*
+*v1.2.1-develop.10*
 
 Build status (on Travis CI) [![Build Status](https://travis-ci.org/philsquared/Catch.png)](https://travis-ci.org/philsquared/Catch)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![catch logo](catch-logo-small.png)
 
-*v1.2.1*
+*v1.2.1-develop.1*
 
 Build status (on Travis CI) [![Build Status](https://travis-ci.org/philsquared/Catch.png)](https://travis-ci.org/philsquared/Catch)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![catch logo](catch-logo-small.png)
 
-*v1.2.1-develop.8*
+*v1.2.1-develop.9*
 
 Build status (on Travis CI) [![Build Status](https://travis-ci.org/philsquared/Catch.png)](https://travis-ci.org/philsquared/Catch)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![catch logo](catch-logo-small.png)
 
-*v1.2.1-develop.3*
+*v1.2.1-develop.4*
 
 Build status (on Travis CI) [![Build Status](https://travis-ci.org/philsquared/Catch.png)](https://travis-ci.org/philsquared/Catch)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![catch logo](catch-logo-small.png)
 
-*v1.2.1-develop.5*
+*v1.2.1-develop.6*
 
 Build status (on Travis CI) [![Build Status](https://travis-ci.org/philsquared/Catch.png)](https://travis-ci.org/philsquared/Catch)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![catch logo](catch-logo-small.png)
 
-*v1.2.1-develop.2*
+*v1.2.1-develop.3*
 
 Build status (on Travis CI) [![Build Status](https://travis-ci.org/philsquared/Catch.png)](https://travis-ci.org/philsquared/Catch)
 

--- a/docs/test-cases-and-sections.md
+++ b/docs/test-cases-and-sections.md
@@ -28,9 +28,35 @@ The tag expression, ```"[widget]"``` selects A, B & D. ```"[gadget]"``` selects 
 
 For more detail on command line selection see [the command line docs](command-line.md#specifying-which-tests-to-run)
 
-A special tag name, ```[hide]``` causes test cases to be skipped from the default list (ie when no test cases have been explicitly selected through tag expressions or name wildcards). ```[.]``` is an alias for ```[hide]```.
-
 Tag names are not case sensitive.
+
+### Special Tags
+
+All tag names beginning with non-alphanumeric characters are reserved by Catch. Catch defines a number of "special" tags, which have meaning to the test runner itself. These special tags all begin with a symbol character. Following is a list of currently defined special tags and their meanings.
+
+* `[!hide]` or `[.]` (or, for legacy reasons, `[hide]`)	- causes test cases to be skipped from the default list (ie when no test cases have been explicitly selected through tag expressions or name wildcards). The hide tag is often combined with another, user, tag (for example `[.][integration]` - so all integration tests are excluded from the default run but can be run by passing `[integration]` on the command line). As a short-cut you can combine these by simply prefixing your user tag with a `.` - e.g. `[.integration]`. Because the hide tag has evolved to have several forms, all forms are added as tags if you use one of them.
+
+* `[!throws]`	- lets Catch know that this test is likely to throw an exception even if successful. This causes the test to be exluded when running with `-e` or `--nothrow`.
+
+* `[!shouldfail]` - reverse the failing logic of the test: if the test is successful if it fails, and vice-versa.
+
+* `[!mayfail]` - doesn't fail the test if any given assertion fails (but still reports it). This can be useful to flag a work-in-progress, or a known issue that you don't want to immediately fix but still want to track in the your tests.
+
+* `[#<filename>]` - running with `-#` or `--filenames-as-tags` causes Catch to add the filename, prefixed with `#` (and with any extension stripped) as a tag. e.g. tests in testfile.cpp would all be tagged `[#testfile]`.
+
+* `[@<alias>]` - tag aliases all begin with `@` (see below).
+
+## Tag aliases
+
+Between tag expressions and wildcarded test names (as well as combinations of the two) quite complex patterns can be constructed to direct which test cases are run. If a complex pattern is used often it is convenient to be able to create an alias for the expression. this can be done, in code, using the following form:
+
+	CATCH_REGISTER_TAG_ALIAS( <alias string>, <tag expression> )
+
+Aliases must begining with the `@` character. An example of a tag alias is:
+
+	CATCH_REGISTER_TAG_ALIAS( "[@nhf]", "[failing]~[.]" )
+
+Now when `[@nhf]` is used on the command line this matches all tests that are tagged `[failing]`, but which are not also hidden.
 
 ## BDD-style test cases
 

--- a/include/catch.hpp
+++ b/include/catch.hpp
@@ -72,7 +72,7 @@
 
 #define CATCH_REQUIRE_THROWS( expr ) INTERNAL_CATCH_THROWS( expr, Catch::ResultDisposition::Normal, "", "CATCH_REQUIRE_THROWS" )
 #define CATCH_REQUIRE_THROWS_AS( expr, exceptionType ) INTERNAL_CATCH_THROWS_AS( expr, exceptionType, Catch::ResultDisposition::Normal, "CATCH_REQUIRE_THROWS_AS" )
-#define CATCH_REQUIRE_THROWS_WITH( expr, expectedMessage ) INTERNAL_CATCH_THROWS( expr, Catch::ResultDisposition::Normal, expectedMessage, "CATCH_REQUIRE_THROWS_WITH" )
+#define CATCH_REQUIRE_THROWS_WITH( expr, matcher ) INTERNAL_CATCH_THROWS( expr, Catch::ResultDisposition::Normal, matcher, "CATCH_REQUIRE_THROWS_WITH" )
 #define CATCH_REQUIRE_NOTHROW( expr ) INTERNAL_CATCH_NO_THROW( expr, Catch::ResultDisposition::Normal, "CATCH_REQUIRE_NOTHROW" )
 
 #define CATCH_CHECK( expr ) INTERNAL_CATCH_TEST( expr, Catch::ResultDisposition::ContinueOnFailure, "CATCH_CHECK" )
@@ -83,7 +83,7 @@
 
 #define CATCH_CHECK_THROWS( expr )  INTERNAL_CATCH_THROWS( expr, Catch::ResultDisposition::ContinueOnFailure, "CATCH_CHECK_THROWS" )
 #define CATCH_CHECK_THROWS_AS( expr, exceptionType ) INTERNAL_CATCH_THROWS_AS( expr, exceptionType, Catch::ResultDisposition::ContinueOnFailure, "CATCH_CHECK_THROWS_AS" )
-#define CATCH_CHECK_THROWS_WITH( expr, expectedMessage ) INTERNAL_CATCH_THROWS( expr, Catch::ResultDisposition::ContinueOnFailure, expectedMessage, "CATCH_CHECK_THROWS_WITH" )
+#define CATCH_CHECK_THROWS_WITH( expr, matcher ) INTERNAL_CATCH_THROWS( expr, Catch::ResultDisposition::ContinueOnFailure, matcher, "CATCH_CHECK_THROWS_WITH" )
 #define CATCH_CHECK_NOTHROW( expr ) INTERNAL_CATCH_NO_THROW( expr, Catch::ResultDisposition::ContinueOnFailure, "CATCH_CHECK_NOTHROW" )
 
 #define CHECK_THAT( arg, matcher ) INTERNAL_CHECK_THAT( arg, matcher, Catch::ResultDisposition::ContinueOnFailure, "CATCH_CHECK_THAT" )
@@ -139,7 +139,7 @@
 
 #define REQUIRE_THROWS( expr ) INTERNAL_CATCH_THROWS( expr, Catch::ResultDisposition::Normal, "", "REQUIRE_THROWS" )
 #define REQUIRE_THROWS_AS( expr, exceptionType ) INTERNAL_CATCH_THROWS_AS( expr, exceptionType, Catch::ResultDisposition::Normal, "REQUIRE_THROWS_AS" )
-#define REQUIRE_THROWS_WITH( expr, expectedMessage ) INTERNAL_CATCH_THROWS( expr, Catch::ResultDisposition::Normal, expectedMessage, "REQUIRE_THROWS_WITH" )
+#define REQUIRE_THROWS_WITH( expr, matcher ) INTERNAL_CATCH_THROWS( expr, Catch::ResultDisposition::Normal, matcher, "REQUIRE_THROWS_WITH" )
 #define REQUIRE_NOTHROW( expr ) INTERNAL_CATCH_NO_THROW( expr, Catch::ResultDisposition::Normal, "REQUIRE_NOTHROW" )
 
 #define CHECK( expr ) INTERNAL_CATCH_TEST( expr, Catch::ResultDisposition::ContinueOnFailure, "CHECK" )
@@ -150,7 +150,7 @@
 
 #define CHECK_THROWS( expr )  INTERNAL_CATCH_THROWS( expr, Catch::ResultDisposition::ContinueOnFailure, "", "CHECK_THROWS" )
 #define CHECK_THROWS_AS( expr, exceptionType ) INTERNAL_CATCH_THROWS_AS( expr, exceptionType, Catch::ResultDisposition::ContinueOnFailure, "CHECK_THROWS_AS" )
-#define CHECK_THROWS_WITH( expr, expectedMessage ) INTERNAL_CATCH_THROWS( expr, Catch::ResultDisposition::ContinueOnFailure, expectedMessage, "CHECK_THROWS_WITH" )
+#define CHECK_THROWS_WITH( expr, matcher ) INTERNAL_CATCH_THROWS( expr, Catch::ResultDisposition::ContinueOnFailure, matcher, "CHECK_THROWS_WITH" )
 #define CHECK_NOTHROW( expr ) INTERNAL_CATCH_NO_THROW( expr, Catch::ResultDisposition::ContinueOnFailure, "CHECK_NOTHROW" )
 
 #define CHECK_THAT( arg, matcher ) INTERNAL_CHECK_THAT( arg, matcher, Catch::ResultDisposition::ContinueOnFailure, "CHECK_THAT" )

--- a/include/catch.hpp
+++ b/include/catch.hpp
@@ -125,11 +125,11 @@
 #define CATCH_SCENARIO( name, tags ) CATCH_TEST_CASE( "Scenario: " name, tags )
 #define CATCH_SCENARIO_METHOD( className, name, tags ) INTERNAL_CATCH_TEST_CASE_METHOD( className, "Scenario: " name, tags )
 #endif
-#define CATCH_GIVEN( desc )    CATCH_SECTION( "Given: " desc, "" )
-#define CATCH_WHEN( desc )     CATCH_SECTION( " When: " desc, "" )
-#define CATCH_AND_WHEN( desc ) CATCH_SECTION( "  And: " desc, "" )
-#define CATCH_THEN( desc )     CATCH_SECTION( " Then: " desc, "" )
-#define CATCH_AND_THEN( desc ) CATCH_SECTION( "  And: " desc, "" )
+#define CATCH_GIVEN( desc )    CATCH_SECTION( std::string( "Given: ") + desc, "" )
+#define CATCH_WHEN( desc )     CATCH_SECTION( std::string( " When: ") + desc, "" )
+#define CATCH_AND_WHEN( desc ) CATCH_SECTION( std::string( "  And: ") + desc, "" )
+#define CATCH_THEN( desc )     CATCH_SECTION( std::string( " Then: ") + desc, "" )
+#define CATCH_AND_THEN( desc ) CATCH_SECTION( std::string( "  And: ") + desc, "" )
 
 // If CATCH_CONFIG_PREFIX_ALL is not defined then the CATCH_ prefix is not required
 #else
@@ -196,11 +196,11 @@
 #define SCENARIO( name, tags ) TEST_CASE( "Scenario: " name, tags )
 #define SCENARIO_METHOD( className, name, tags ) INTERNAL_CATCH_TEST_CASE_METHOD( className, "Scenario: " name, tags )
 #endif
-#define GIVEN( desc )    SECTION( "   Given: " desc, "" )
-#define WHEN( desc )     SECTION( "    When: " desc, "" )
-#define AND_WHEN( desc ) SECTION( "And when: " desc, "" )
-#define THEN( desc )     SECTION( "    Then: " desc, "" )
-#define AND_THEN( desc ) SECTION( "     And: " desc, "" )
+#define GIVEN( desc )    SECTION( std::string("   Given: ") + desc, "" )
+#define WHEN( desc )     SECTION( std::string("    When: ") + desc, "" )
+#define AND_WHEN( desc ) SECTION( std::string("And when: ") + desc, "" )
+#define THEN( desc )     SECTION( std::string("    Then: ") + desc, "" )
+#define AND_THEN( desc ) SECTION( std::string("     And: ") + desc, "" )
 
 using Catch::Detail::Approx;
 

--- a/include/catch.hpp
+++ b/include/catch.hpp
@@ -70,8 +70,9 @@
 #define CATCH_REQUIRE( expr ) INTERNAL_CATCH_TEST( expr, Catch::ResultDisposition::Normal, "CATCH_REQUIRE" )
 #define CATCH_REQUIRE_FALSE( expr ) INTERNAL_CATCH_TEST( expr, Catch::ResultDisposition::Normal | Catch::ResultDisposition::FalseTest, "CATCH_REQUIRE_FALSE" )
 
-#define CATCH_REQUIRE_THROWS( expr ) INTERNAL_CATCH_THROWS( expr, Catch::ResultDisposition::Normal, "CATCH_REQUIRE_THROWS" )
+#define CATCH_REQUIRE_THROWS( expr ) INTERNAL_CATCH_THROWS( expr, Catch::ResultDisposition::Normal, "", "CATCH_REQUIRE_THROWS" )
 #define CATCH_REQUIRE_THROWS_AS( expr, exceptionType ) INTERNAL_CATCH_THROWS_AS( expr, exceptionType, Catch::ResultDisposition::Normal, "CATCH_REQUIRE_THROWS_AS" )
+#define CATCH_REQUIRE_THROWS_WITH( expr, expectedMessage ) INTERNAL_CATCH_THROWS( expr, Catch::ResultDisposition::Normal, expectedMessage, "CATCH_REQUIRE_THROWS_WITH" )
 #define CATCH_REQUIRE_NOTHROW( expr ) INTERNAL_CATCH_NO_THROW( expr, Catch::ResultDisposition::Normal, "CATCH_REQUIRE_NOTHROW" )
 
 #define CATCH_CHECK( expr ) INTERNAL_CATCH_TEST( expr, Catch::ResultDisposition::ContinueOnFailure, "CATCH_CHECK" )
@@ -82,6 +83,7 @@
 
 #define CATCH_CHECK_THROWS( expr )  INTERNAL_CATCH_THROWS( expr, Catch::ResultDisposition::ContinueOnFailure, "CATCH_CHECK_THROWS" )
 #define CATCH_CHECK_THROWS_AS( expr, exceptionType ) INTERNAL_CATCH_THROWS_AS( expr, exceptionType, Catch::ResultDisposition::ContinueOnFailure, "CATCH_CHECK_THROWS_AS" )
+#define CATCH_CHECK_THROWS_WITH( expr, expectedMessage ) INTERNAL_CATCH_THROWS( expr, Catch::ResultDisposition::ContinueOnFailure, expectedMessage, "CATCH_CHECK_THROWS_WITH" )
 #define CATCH_CHECK_NOTHROW( expr ) INTERNAL_CATCH_NO_THROW( expr, Catch::ResultDisposition::ContinueOnFailure, "CATCH_CHECK_NOTHROW" )
 
 #define CHECK_THAT( arg, matcher ) INTERNAL_CHECK_THAT( arg, matcher, Catch::ResultDisposition::ContinueOnFailure, "CATCH_CHECK_THAT" )
@@ -135,8 +137,9 @@
 #define REQUIRE( expr ) INTERNAL_CATCH_TEST( expr, Catch::ResultDisposition::Normal, "REQUIRE" )
 #define REQUIRE_FALSE( expr ) INTERNAL_CATCH_TEST( expr, Catch::ResultDisposition::Normal | Catch::ResultDisposition::FalseTest, "REQUIRE_FALSE" )
 
-#define REQUIRE_THROWS( expr ) INTERNAL_CATCH_THROWS( expr, Catch::ResultDisposition::Normal, "REQUIRE_THROWS" )
+#define REQUIRE_THROWS( expr ) INTERNAL_CATCH_THROWS( expr, Catch::ResultDisposition::Normal, "", "REQUIRE_THROWS" )
 #define REQUIRE_THROWS_AS( expr, exceptionType ) INTERNAL_CATCH_THROWS_AS( expr, exceptionType, Catch::ResultDisposition::Normal, "REQUIRE_THROWS_AS" )
+#define REQUIRE_THROWS_WITH( expr, expectedMessage ) INTERNAL_CATCH_THROWS( expr, Catch::ResultDisposition::Normal, expectedMessage, "REQUIRE_THROWS_WITH" )
 #define REQUIRE_NOTHROW( expr ) INTERNAL_CATCH_NO_THROW( expr, Catch::ResultDisposition::Normal, "REQUIRE_NOTHROW" )
 
 #define CHECK( expr ) INTERNAL_CATCH_TEST( expr, Catch::ResultDisposition::ContinueOnFailure, "CHECK" )
@@ -145,8 +148,9 @@
 #define CHECKED_ELSE( expr ) INTERNAL_CATCH_ELSE( expr, Catch::ResultDisposition::ContinueOnFailure, "CHECKED_ELSE" )
 #define CHECK_NOFAIL( expr ) INTERNAL_CATCH_TEST( expr, Catch::ResultDisposition::ContinueOnFailure | Catch::ResultDisposition::SuppressFail, "CHECK_NOFAIL" )
 
-#define CHECK_THROWS( expr )  INTERNAL_CATCH_THROWS( expr, Catch::ResultDisposition::ContinueOnFailure, "CHECK_THROWS" )
+#define CHECK_THROWS( expr )  INTERNAL_CATCH_THROWS( expr, Catch::ResultDisposition::ContinueOnFailure, "", "CHECK_THROWS" )
 #define CHECK_THROWS_AS( expr, exceptionType ) INTERNAL_CATCH_THROWS_AS( expr, exceptionType, Catch::ResultDisposition::ContinueOnFailure, "CHECK_THROWS_AS" )
+#define CHECK_THROWS_WITH( expr, expectedMessage ) INTERNAL_CATCH_THROWS( expr, Catch::ResultDisposition::ContinueOnFailure, expectedMessage, "CHECK_THROWS_WITH" )
 #define CHECK_NOTHROW( expr ) INTERNAL_CATCH_NO_THROW( expr, Catch::ResultDisposition::ContinueOnFailure, "CHECK_NOTHROW" )
 
 #define CHECK_THAT( arg, matcher ) INTERNAL_CHECK_THAT( arg, matcher, Catch::ResultDisposition::ContinueOnFailure, "CHECK_THAT" )

--- a/include/catch_runner.hpp
+++ b/include/catch_runner.hpp
@@ -120,7 +120,7 @@ namespace Catch {
             if( lastDot != std::string::npos )
                 filename = filename.substr( 0, lastDot );
             
-            tags.insert( "@" + filename );
+            tags.insert( "#" + filename );
             setTags( test, tags );
         }
     }

--- a/include/catch_runner.hpp
+++ b/include/catch_runner.hpp
@@ -198,7 +198,7 @@ namespace Catch {
                 if( m_configData.filenamesAsTags )
                     applyFilenamesAsTags();
                 
-                std::srand( m_configData.rngSeed );
+                seedRng( *m_config );
 
                 Runner runner( m_config );
 

--- a/include/catch_runner.hpp
+++ b/include/catch_runner.hpp
@@ -104,6 +104,26 @@ namespace Catch {
         Ptr<IStreamingReporter> m_reporter;
         std::set<TestCase> m_testsAlreadyRun;
     };
+    
+    void applyFilenamesAsTags() {
+        std::vector<TestCase> const& tests = getRegistryHub().getTestCaseRegistry().getAllTests();
+        for(std::size_t i = 0; i < tests.size(); ++i ) {
+            TestCase& test = const_cast<TestCase&>( tests[i] );
+            std::set<std::string> tags = test.tags;
+            
+            std::string filename = test.lineInfo.file;
+            std::string::size_type lastSlash = filename.find_last_of( "\//" );
+            if( lastSlash != std::string::npos )
+                filename = filename.substr( lastSlash+1 );
+
+            std::string::size_type lastDot = filename.find_last_of( "." );
+            if( lastDot != std::string::npos )
+                filename = filename.substr( 0, lastDot );
+            
+            tags.insert( "@" + filename );
+            setTags( test, tags );
+        }
+    }
 
     class Session : NonCopyable {
         static bool alreadyInstantiated;
@@ -175,6 +195,9 @@ namespace Catch {
             {
                 config(); // Force config to be constructed
 
+                if( m_configData.filenamesAsTags )
+                    applyFilenamesAsTags();
+                
                 std::srand( m_configData.rngSeed );
 
                 Runner runner( m_config );

--- a/include/catch_runner.hpp
+++ b/include/catch_runner.hpp
@@ -112,7 +112,7 @@ namespace Catch {
             std::set<std::string> tags = test.tags;
             
             std::string filename = test.lineInfo.file;
-            std::string::size_type lastSlash = filename.find_last_of( "\//" );
+            std::string::size_type lastSlash = filename.find_last_of( "\\/" );
             if( lastSlash != std::string::npos )
                 filename = filename.substr( lastSlash+1 );
 

--- a/include/external/clara.h
+++ b/include/external/clara.h
@@ -264,11 +264,11 @@ namespace Clara {
         template<typename ConfigT>
         class BoundArgFunction {
         public:
-            BoundArgFunction() : functionObj( NULL ) {}
+            BoundArgFunction() : functionObj( CATCH_NULL ) {}
             BoundArgFunction( IArgFunction<ConfigT>* _functionObj ) : functionObj( _functionObj ) {}
-            BoundArgFunction( BoundArgFunction const& other ) : functionObj( other.functionObj ? other.functionObj->clone() : NULL ) {}
+            BoundArgFunction( BoundArgFunction const& other ) : functionObj( other.functionObj ? other.functionObj->clone() : CATCH_NULL ) {}
             BoundArgFunction& operator = ( BoundArgFunction const& other ) {
-                IArgFunction<ConfigT>* newFunctionObj = other.functionObj ? other.functionObj->clone() : NULL;
+                IArgFunction<ConfigT>* newFunctionObj = other.functionObj ? other.functionObj->clone() : CATCH_NULL;
                 delete functionObj;
                 functionObj = newFunctionObj;
                 return *this;
@@ -284,7 +284,7 @@ namespace Clara {
             bool takesArg() const { return functionObj->takesArg(); }
 
             bool isSet() const {
-                return functionObj != NULL;
+                return functionObj != CATCH_NULL;
             }
         private:
             IArgFunction<ConfigT>* functionObj;

--- a/include/external/clara.h
+++ b/include/external/clara.h
@@ -585,8 +585,8 @@ namespace Clara {
                 m_arg->description = description;
                 return *this;
             }
-            ArgBuilder& detail( std::string const& detail ) {
-                m_arg->detail = detail;
+            ArgBuilder& detail( std::string const& _detail ) {
+                m_arg->detail = _detail;
                 return *this;
             }
 
@@ -670,14 +670,14 @@ namespace Clara {
                 maxWidth = (std::max)( maxWidth, it->commands().size() );
 
             for( it = itBegin; it != itEnd; ++it ) {
-                Detail::Text usage( it->commands(), Detail::TextAttributes()
+                Detail::Text usageText( it->commands(), Detail::TextAttributes()
                                                         .setWidth( maxWidth+indent )
                                                         .setIndent( indent ) );
                 Detail::Text desc( it->description, Detail::TextAttributes()
                                                         .setWidth( width - maxWidth - 3 ) );
 
-                for( std::size_t i = 0; i < (std::max)( usage.size(), desc.size() ); ++i ) {
-                    std::string usageCol = i < usage.size() ? usage[i] : "";
+                for( std::size_t i = 0; i < (std::max)( usageText.size(), desc.size() ); ++i ) {
+                    std::string usageCol = i < usageText.size() ? usageText[i] : "";
                     os << usageCol;
 
                     if( i < desc.size() && !desc[i].empty() )

--- a/include/internal/catch_capture.hpp
+++ b/include/internal/catch_capture.hpp
@@ -66,16 +66,16 @@
     } while( Catch::alwaysFalse() )
 
 ///////////////////////////////////////////////////////////////////////////////
-#define INTERNAL_CATCH_THROWS( expr, resultDisposition, expectedMessage, macroName ) \
+#define INTERNAL_CATCH_THROWS( expr, resultDisposition, matcher, macroName ) \
     do { \
-        Catch::ResultBuilder __catchResult( macroName, CATCH_INTERNAL_LINEINFO, #expr, resultDisposition, expectedMessage ); \
+        Catch::ResultBuilder __catchResult( macroName, CATCH_INTERNAL_LINEINFO, #expr, resultDisposition, #matcher ); \
         if( __catchResult.allowThrows() ) \
             try { \
                 expr; \
                 __catchResult.captureResult( Catch::ResultWas::DidntThrowException ); \
             } \
             catch( ... ) { \
-                __catchResult.captureExpectedException( expectedMessage ); \
+                __catchResult.captureExpectedException( matcher ); \
             } \
         else \
             __catchResult.captureResult( Catch::ResultWas::Ok ); \

--- a/include/internal/catch_capture.hpp
+++ b/include/internal/catch_capture.hpp
@@ -66,16 +66,16 @@
     } while( Catch::alwaysFalse() )
 
 ///////////////////////////////////////////////////////////////////////////////
-#define INTERNAL_CATCH_THROWS( expr, resultDisposition, macroName ) \
+#define INTERNAL_CATCH_THROWS( expr, resultDisposition, expectedMessage, macroName ) \
     do { \
-        Catch::ResultBuilder __catchResult( macroName, CATCH_INTERNAL_LINEINFO, #expr, resultDisposition ); \
+        Catch::ResultBuilder __catchResult( macroName, CATCH_INTERNAL_LINEINFO, #expr, resultDisposition, expectedMessage ); \
         if( __catchResult.allowThrows() ) \
             try { \
                 expr; \
                 __catchResult.captureResult( Catch::ResultWas::DidntThrowException ); \
             } \
             catch( ... ) { \
-                __catchResult.captureResult( Catch::ResultWas::Ok ); \
+                __catchResult.captureExpectedException( expectedMessage ); \
             } \
         else \
             __catchResult.captureResult( Catch::ResultWas::Ok ); \

--- a/include/internal/catch_commandline.hpp
+++ b/include/internal/catch_commandline.hpp
@@ -174,6 +174,10 @@ namespace Catch {
             .describe( "force colourised output" )
             .bind( &ConfigData::forceColour );
 
+        cli["--filenames-as-tags"]
+            .describe( "adds a tag for the filename" )
+            .bind( &ConfigData::filenamesAsTags );
+        
         return cli;
     }
 

--- a/include/internal/catch_commandline.hpp
+++ b/include/internal/catch_commandline.hpp
@@ -153,6 +153,10 @@ namespace Catch {
             .describe( "load test names to run from a file" )
             .bind( &loadTestNamesFromFile, "filename" );
 
+        cli["-#"]["--filenames-as-tags"]
+            .describe( "adds a tag for the filename" )
+            .bind( &ConfigData::filenamesAsTags );
+
         // Less common commands which don't have a short form
         cli["--list-test-names-only"]
             .describe( "list all/matching test cases names only" )
@@ -173,10 +177,6 @@ namespace Catch {
         cli["--force-colour"]
             .describe( "force colourised output" )
             .bind( &ConfigData::forceColour );
-
-        cli["--filenames-as-tags"]
-            .describe( "adds a tag for the filename" )
-            .bind( &ConfigData::filenamesAsTags );
         
         return cli;
     }

--- a/include/internal/catch_common.h
+++ b/include/internal/catch_common.h
@@ -22,6 +22,8 @@
 #include "catch_compiler_capabilities.h"
 
 namespace Catch {
+    
+    struct IConfig;
 
     class NonCopyable {
 #ifdef CATCH_CONFIG_CPP11_GENERATED_METHODS
@@ -109,6 +111,9 @@ namespace Catch {
 
     void throwLogicError( std::string const& message, SourceLineInfo const& locationInfo );
 
+    void seedRng( IConfig const& config );
+    unsigned int rngSeed();
+    
     // Use this in variadic streaming macros to allow
     //    >> +StreamEndStop
     // as well as

--- a/include/internal/catch_common.h
+++ b/include/internal/catch_common.h
@@ -25,6 +25,11 @@ namespace Catch {
     
     struct IConfig;
 
+    struct CaseSensitive { enum Choice {
+        Yes,
+        No
+    }; };
+    
     class NonCopyable {
 #ifdef CATCH_CONFIG_CPP11_GENERATED_METHODS
         NonCopyable( NonCopyable const& )              = delete;

--- a/include/internal/catch_common.hpp
+++ b/include/internal/catch_common.hpp
@@ -82,6 +82,14 @@ namespace Catch {
         return line < other.line || ( line == other.line  && file < other.file );
     }
 
+    void seedRng( IConfig const& config ) {
+        if( config.rngSeed() != 0 )
+            std::srand( config.rngSeed() );
+    }
+    unsigned int rngSeed() {
+        return getCurrentContext().getConfig()->rngSeed();
+    }
+
     std::ostream& operator << ( std::ostream& os, SourceLineInfo const& info ) {
 #ifndef __GNUG__
         os << info.file << "(" << info.line << ")";

--- a/include/internal/catch_compiler_capabilities.h
+++ b/include/internal/catch_compiler_capabilities.h
@@ -16,6 +16,7 @@
 // CATCH_CONFIG_CPP11_GENERATED_METHODS : The delete and default keywords for compiler generated methods
 // CATCH_CONFIG_CPP11_IS_ENUM : std::is_enum is supported?
 // CATCH_CONFIG_CPP11_TUPLE : std::tuple is supported
+// CATCH_CONFIG_CPP11_LONG_LONG : is long long supported?
 
 // CATCH_CONFIG_CPP11_OR_GREATER : Is C++11 supported?
 
@@ -130,6 +131,10 @@
 #    define CATCH_INTERNAL_CONFIG_VARIADIC_MACROS
 #  endif
 
+#  if !defined(CATCH_INTERNAL_CONFIG_CPP11_LONG_LONG)
+#    define CATCH_INTERNAL_CONFIG_CPP11_LONG_LONG
+#  endif
+
 #endif // __cplusplus >= 201103L
 
 // Now set the actual defines based on the above + anything the user has configured
@@ -149,7 +154,10 @@
 #   define CATCH_CONFIG_CPP11_TUPLE
 #endif
 #if defined(CATCH_INTERNAL_CONFIG_VARIADIC_MACROS) && !defined(CATCH_CONFIG_NO_VARIADIC_MACROS) && !defined(CATCH_CONFIG_VARIADIC_MACROS)
-#define CATCH_CONFIG_VARIADIC_MACROS
+#   define CATCH_CONFIG_VARIADIC_MACROS
+#endif
+#if defined(CATCH_INTERNAL_CONFIG_CPP11_LONG_LONG) && !defined(CATCH_CONFIG_NO_LONG_LONG) && !defined(CATCH_CONFIG_CPP11_LONG_LONG)
+#   define CATCH_CONFIG_CPP11_LONG_LONG
 #endif
 
 

--- a/include/internal/catch_compiler_capabilities.h
+++ b/include/internal/catch_compiler_capabilities.h
@@ -67,7 +67,7 @@
 // GCC
 #ifdef __GNUC__
 
-#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6 && defined(__GXX_EXPERIMENTAL_CXX0X__) )
+#if (__GNUC__ > 4 && __cplusplus >= 201103L) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6 && defined(__GXX_EXPERIMENTAL_CXX0X__) )
 #   define CATCH_INTERNAL_CONFIG_CPP11_NULLPTR
 #endif
 

--- a/include/internal/catch_compiler_capabilities.h
+++ b/include/internal/catch_compiler_capabilities.h
@@ -162,6 +162,12 @@
 #  define CATCH_NOEXCEPT_IS(x)
 #endif
 
+// nullptr support
+#ifdef CATCH_CONFIG_CPP11_NULLPTR
+#   define CATCH_NULL nullptr
+#else
+#   define CATCH_NULL NULL
+#endif
 
 #endif // TWOBLUECUBES_CATCH_COMPILER_CAPABILITIES_HPP_INCLUDED
 

--- a/include/internal/catch_config.hpp
+++ b/include/internal/catch_config.hpp
@@ -38,6 +38,7 @@ namespace Catch {
             showHelp( false ),
             showInvisibles( false ),
             forceColour( false ),
+            filenamesAsTags( false ),
             abortAfter( -1 ),
             rngSeed( 0 ),
             verbosity( Verbosity::Normal ),
@@ -57,6 +58,7 @@ namespace Catch {
         bool showHelp;
         bool showInvisibles;
         bool forceColour;
+        bool filenamesAsTags;
 
         int abortAfter;
         unsigned int rngSeed;

--- a/include/internal/catch_console_colour_impl.hpp
+++ b/include/internal/catch_console_colour_impl.hpp
@@ -60,12 +60,13 @@ namespace {
         {
             CONSOLE_SCREEN_BUFFER_INFO csbiInfo;
             GetConsoleScreenBufferInfo( stdoutHandle, &csbiInfo );
-            originalAttributes = csbiInfo.wAttributes;
+            originalForegroundAttributes = csbiInfo.wAttributes & ~( BACKGROUND_GREEN | BACKGROUND_RED | BACKGROUND_BLUE | BACKGROUND_INTENSITY );
+            originalBackgroundAttributes = csbiInfo.wAttributes & ~( FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_INTENSITY );
         }
 
         virtual void use( Colour::Code _colourCode ) {
             switch( _colourCode ) {
-                case Colour::None:      return setTextAttribute( originalAttributes );
+                case Colour::None:      return setTextAttribute( originalForegroundAttributes );
                 case Colour::White:     return setTextAttribute( FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE );
                 case Colour::Red:       return setTextAttribute( FOREGROUND_RED );
                 case Colour::Green:     return setTextAttribute( FOREGROUND_GREEN );
@@ -85,10 +86,11 @@ namespace {
 
     private:
         void setTextAttribute( WORD _textAttribute ) {
-            SetConsoleTextAttribute( stdoutHandle, _textAttribute );
+            SetConsoleTextAttribute( stdoutHandle, _textAttribute | originalBackgroundAttributes );
         }
         HANDLE stdoutHandle;
-        WORD originalAttributes;
+        WORD originalForegroundAttributes;
+        WORD originalBackgroundAttributes;
     };
 
     IColourImpl* platformColourInstance() {

--- a/include/internal/catch_context_impl.hpp
+++ b/include/internal/catch_context_impl.hpp
@@ -17,7 +17,7 @@ namespace Catch {
 
     class Context : public IMutableContext {
 
-        Context() : m_config( NULL ), m_runner( NULL ), m_resultCapture( NULL ) {}
+        Context() : m_config( CATCH_NULL ), m_runner( CATCH_NULL ), m_resultCapture( CATCH_NULL ) {}
         Context( Context const& );
         void operator=( Context const& );
 
@@ -63,7 +63,7 @@ namespace Catch {
                 m_generatorsByTestName.find( testName );
             return it != m_generatorsByTestName.end()
                 ? it->second
-                : NULL;
+                : CATCH_NULL;
         }
 
         IGeneratorsForTest& getGeneratorsForCurrentTest() {
@@ -84,7 +84,7 @@ namespace Catch {
     };
 
     namespace {
-        Context* currentContext = NULL;
+        Context* currentContext = CATCH_NULL;
     }
     IMutableContext& getCurrentMutableContext() {
         if( !currentContext )
@@ -105,7 +105,7 @@ namespace Catch {
 
     void cleanUpContext() {
         delete currentContext;
-        currentContext = NULL;
+        currentContext = CATCH_NULL;
     }
 }
 

--- a/include/internal/catch_debugger.hpp
+++ b/include/internal/catch_debugger.hpp
@@ -50,7 +50,7 @@
             // Call sysctl.
 
             size = sizeof(info);
-            if( sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &size, NULL, 0) != 0 ) {
+            if( sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &size, CATCH_NULL, 0) != 0 ) {
                 Catch::cerr() << "\n** Call to sysctl failed - unable to determine if debugger is active **\n" << std::endl;
                 return false;
             }

--- a/include/internal/catch_evaluate.hpp
+++ b/include/internal/catch_evaluate.hpp
@@ -160,13 +160,51 @@ namespace Internal {
         return Evaluator<T*, T*, Op>::evaluate( lhs, reinterpret_cast<T*>( rhs ) );
     }
 
+#ifdef CATCH_CONFIG_CPP11_LONG_LONG
+    // long long to unsigned X
+    template<Operator Op> bool compare( long long lhs, unsigned int rhs ) {
+        return applyEvaluator<Op>( static_cast<unsigned long>( lhs ), rhs );
+    }
+    template<Operator Op> bool compare( long long lhs, unsigned long rhs ) {
+        return applyEvaluator<Op>( static_cast<unsigned long>( lhs ), rhs );
+    }
+    template<Operator Op> bool compare( long long lhs, unsigned long long rhs ) {
+        return applyEvaluator<Op>( static_cast<unsigned long>( lhs ), rhs );
+    }
+    template<Operator Op> bool compare( long long lhs, unsigned char rhs ) {
+        return applyEvaluator<Op>( static_cast<unsigned long>( lhs ), rhs );
+    }
+    
+    // unsigned long long to X
+    template<Operator Op> bool compare( unsigned long long lhs, int rhs ) {
+        return applyEvaluator<Op>( static_cast<long>( lhs ), rhs );
+    }
+    template<Operator Op> bool compare( unsigned long long lhs, long rhs ) {
+        return applyEvaluator<Op>( static_cast<long>( lhs ), rhs );
+    }
+    template<Operator Op> bool compare( unsigned long long lhs, long long rhs ) {
+        return applyEvaluator<Op>( static_cast<long>( lhs ), rhs );
+    }
+    template<Operator Op> bool compare( unsigned long long lhs, char rhs ) {
+        return applyEvaluator<Op>( static_cast<long>( lhs ), rhs );
+    }
+    
+    // pointer to long long (when comparing against NULL)
+    template<Operator Op, typename T> bool compare( long long lhs, T* rhs ) {
+        return Evaluator<T*, T*, Op>::evaluate( reinterpret_cast<T*>( lhs ), rhs );
+    }
+    template<Operator Op, typename T> bool compare( T* lhs, long long rhs ) {
+        return Evaluator<T*, T*, Op>::evaluate( lhs, reinterpret_cast<T*>( rhs ) );
+    }
+#endif // CATCH_CONFIG_CPP11_LONG_LONG
+    
 #ifdef CATCH_CONFIG_CPP11_NULLPTR
     // pointer to nullptr_t (when comparing against nullptr)
     template<Operator Op, typename T> bool compare( std::nullptr_t, T* rhs ) {
-        return Evaluator<T*, T*, Op>::evaluate( CATCH_NULL, rhs );
+        return Evaluator<T*, T*, Op>::evaluate( nullptr, rhs );
     }
     template<Operator Op, typename T> bool compare( T* lhs, std::nullptr_t ) {
-        return Evaluator<T*, T*, Op>::evaluate( lhs, CATCH_NULL );
+        return Evaluator<T*, T*, Op>::evaluate( lhs, nullptr );
     }
 #endif // CATCH_CONFIG_CPP11_NULLPTR
 

--- a/include/internal/catch_evaluate.hpp
+++ b/include/internal/catch_evaluate.hpp
@@ -163,10 +163,10 @@ namespace Internal {
 #ifdef CATCH_CONFIG_CPP11_NULLPTR
     // pointer to nullptr_t (when comparing against nullptr)
     template<Operator Op, typename T> bool compare( std::nullptr_t, T* rhs ) {
-        return Evaluator<T*, T*, Op>::evaluate( NULL, rhs );
+        return Evaluator<T*, T*, Op>::evaluate( CATCH_NULL, rhs );
     }
     template<Operator Op, typename T> bool compare( T* lhs, std::nullptr_t ) {
-        return Evaluator<T*, T*, Op>::evaluate( lhs, NULL );
+        return Evaluator<T*, T*, Op>::evaluate( lhs, CATCH_NULL );
     }
 #endif // CATCH_CONFIG_CPP11_NULLPTR
 

--- a/include/internal/catch_impl.hpp
+++ b/include/internal/catch_impl.hpp
@@ -77,6 +77,7 @@ namespace Catch {
     FreeFunctionTestCase::~FreeFunctionTestCase() {}
     IGeneratorInfo::~IGeneratorInfo() {}
     IGeneratorsForTest::~IGeneratorsForTest() {}
+    WildcardPattern::~WildcardPattern() {}
     TestSpec::Pattern::~Pattern() {}
     TestSpec::NamePattern::~NamePattern() {}
     TestSpec::TagPattern::~TagPattern() {}

--- a/include/internal/catch_matchers.hpp
+++ b/include/internal/catch_matchers.hpp
@@ -108,68 +108,96 @@ namespace Matchers {
         inline std::string makeString( std::string const& str ) { return str; }
         inline std::string makeString( const char* str ) { return str ? std::string( str ) : std::string(); }
 
+        struct CasedString
+        {
+            CasedString( std::string const& str, CaseSensitive::Choice caseSensitivity )
+            :   m_caseSensitivity( caseSensitivity ),
+                m_str( adjustString( str ) )
+            {}
+            std::string adjustString( std::string const& str ) const {
+                return m_caseSensitivity == CaseSensitive::No
+                    ? toLower( str )
+                    : str;
+                
+            }
+            std::string toStringSuffix() const
+            {
+                return m_caseSensitivity == CaseSensitive::No
+                    ? " (case insensitive)"
+                    : "";
+            }
+            CaseSensitive::Choice m_caseSensitivity;
+            std::string m_str;
+        };
+    
         struct Equals : MatcherImpl<Equals, std::string> {
-            Equals( std::string const& str ) : m_str( str ){}
-            Equals( Equals const& other ) : m_str( other.m_str ){}
+            Equals( std::string const& str, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes )
+            :   m_data( str, caseSensitivity )
+            {}
+            Equals( Equals const& other ) : m_data( other.m_data ){}
 
             virtual ~Equals();
 
             virtual bool match( std::string const& expr ) const {
-                return m_str == expr;
+                return m_data.m_str == m_data.adjustString( expr );;
             }
             virtual std::string toString() const {
-                return "equals: \"" + m_str + "\"";
+                return "equals: \"" + m_data.m_str + "\"" + m_data.toStringSuffix();
             }
 
-            std::string m_str;
+            CasedString m_data;
         };
 
         struct Contains : MatcherImpl<Contains, std::string> {
-            Contains( std::string const& substr ) : m_substr( substr ){}
-            Contains( Contains const& other ) : m_substr( other.m_substr ){}
+            Contains( std::string const& substr, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes )
+            : m_data( substr, caseSensitivity ){}
+            Contains( Contains const& other ) : m_data( other.m_data ){}
 
             virtual ~Contains();
 
             virtual bool match( std::string const& expr ) const {
-                return expr.find( m_substr ) != std::string::npos;
+                return m_data.adjustString( expr ).find( m_data.m_str ) != std::string::npos;
             }
             virtual std::string toString() const {
-                return "contains: \"" + m_substr + "\"";
+                return "contains: \"" + m_data.m_str  + "\"" + m_data.toStringSuffix();
             }
 
-            std::string m_substr;
+            CasedString m_data;
         };
 
         struct StartsWith : MatcherImpl<StartsWith, std::string> {
-            StartsWith( std::string const& substr ) : m_substr( substr ){}
-            StartsWith( StartsWith const& other ) : m_substr( other.m_substr ){}
+            StartsWith( std::string const& substr, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes )
+            : m_data( substr, caseSensitivity ){}
+            
+            StartsWith( StartsWith const& other ) : m_data( other.m_data ){}
 
             virtual ~StartsWith();
 
             virtual bool match( std::string const& expr ) const {
-                return expr.find( m_substr ) == 0;
+                return m_data.adjustString( expr ).find( m_data.m_str ) == 0;
             }
             virtual std::string toString() const {
-                return "starts with: \"" + m_substr + "\"";
+                return "starts with: \"" + m_data.m_str + "\"" + m_data.toStringSuffix();
             }
 
-            std::string m_substr;
+            CasedString m_data;
         };
 
         struct EndsWith : MatcherImpl<EndsWith, std::string> {
-            EndsWith( std::string const& substr ) : m_substr( substr ){}
-            EndsWith( EndsWith const& other ) : m_substr( other.m_substr ){}
+            EndsWith( std::string const& substr, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes )
+            : m_data( substr, caseSensitivity ){}
+            EndsWith( EndsWith const& other ) : m_data( other.m_data ){}
 
             virtual ~EndsWith();
 
             virtual bool match( std::string const& expr ) const {
-                return expr.find( m_substr ) == expr.size() - m_substr.size();
+                return m_data.adjustString( expr ).find( m_data.m_str ) == expr.size() - m_data.m_str.size();
             }
             virtual std::string toString() const {
-                return "ends with: \"" + m_substr + "\"";
+                return "ends with: \"" + m_data.m_str + "\"" + m_data.toStringSuffix();
             }
 
-            std::string m_substr;
+            CasedString m_data;
         };
     } // namespace StdString
     } // namespace Impl
@@ -199,17 +227,17 @@ namespace Matchers {
         return Impl::Generic::AnyOf<ExpressionT>().add( m1 ).add( m2 ).add( m3 );
     }
 
-    inline Impl::StdString::Equals      Equals( std::string const& str ) {
-        return Impl::StdString::Equals( str );
+    inline Impl::StdString::Equals      Equals( std::string const& str, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes ) {
+        return Impl::StdString::Equals( str, caseSensitivity );
     }
-    inline Impl::StdString::Equals      Equals( const char* str ) {
-        return Impl::StdString::Equals( Impl::StdString::makeString( str ) );
+    inline Impl::StdString::Equals      Equals( const char* str, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes ) {
+        return Impl::StdString::Equals( Impl::StdString::makeString( str ), caseSensitivity );
     }
-    inline Impl::StdString::Contains    Contains( std::string const& substr ) {
-        return Impl::StdString::Contains( substr );
+    inline Impl::StdString::Contains    Contains( std::string const& substr, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes ) {
+        return Impl::StdString::Contains( substr, caseSensitivity );
     }
-    inline Impl::StdString::Contains    Contains( const char* substr ) {
-        return Impl::StdString::Contains( Impl::StdString::makeString( substr ) );
+    inline Impl::StdString::Contains    Contains( const char* substr, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes ) {
+        return Impl::StdString::Contains( Impl::StdString::makeString( substr ), caseSensitivity );
     }
     inline Impl::StdString::StartsWith  StartsWith( std::string const& substr ) {
         return Impl::StdString::StartsWith( substr );

--- a/include/internal/catch_objc.hpp
+++ b/include/internal/catch_objc.hpp
@@ -72,7 +72,7 @@ namespace Catch {
 
     inline size_t registerTestMethods() {
         size_t noTestMethods = 0;
-        int noClasses = objc_getClassList( NULL, 0 );
+        int noClasses = objc_getClassList( CATCH_NULL, 0 );
 
         Class* classes = (CATCH_UNSAFE_UNRETAINED Class *)malloc( sizeof(Class) * noClasses);
         objc_getClassList( classes, noClasses );

--- a/include/internal/catch_option.hpp
+++ b/include/internal/catch_option.hpp
@@ -16,12 +16,12 @@ namespace Catch {
     template<typename T>
     class Option {
     public:
-        Option() : nullableValue( NULL ) {}
+        Option() : nullableValue( CATCH_NULL ) {}
         Option( T const& _value )
         : nullableValue( new( storage ) T( _value ) )
         {}
         Option( Option const& _other )
-        : nullableValue( _other ? new( storage ) T( *_other ) : NULL )
+        : nullableValue( _other ? new( storage ) T( *_other ) : CATCH_NULL )
         {}
 
         ~Option() {
@@ -45,7 +45,7 @@ namespace Catch {
         void reset() {
             if( nullableValue )
                 nullableValue->~T();
-            nullableValue = NULL;
+            nullableValue = CATCH_NULL;
         }
 
         T& operator*() { return *nullableValue; }
@@ -57,10 +57,10 @@ namespace Catch {
             return nullableValue ? *nullableValue : defaultValue;
         }
 
-        bool some() const { return nullableValue != NULL; }
-        bool none() const { return nullableValue == NULL; }
+        bool some() const { return nullableValue != CATCH_NULL; }
+        bool none() const { return nullableValue == CATCH_NULL; }
 
-        bool operator !() const { return nullableValue == NULL; }
+        bool operator !() const { return nullableValue == CATCH_NULL; }
         operator SafeBool::type() const {
             return SafeBool::makeSafe( some() );
         }

--- a/include/internal/catch_ptr.hpp
+++ b/include/internal/catch_ptr.hpp
@@ -23,7 +23,7 @@ namespace Catch {
     template<typename T>
     class Ptr {
     public:
-        Ptr() : m_p( NULL ){}
+        Ptr() : m_p( CATCH_NULL ){}
         Ptr( T* p ) : m_p( p ){
             if( m_p )
                 m_p->addRef();
@@ -39,7 +39,7 @@ namespace Catch {
         void reset() {
             if( m_p )
                 m_p->release();
-            m_p = NULL;
+            m_p = CATCH_NULL;
         }
         Ptr& operator = ( T* p ){
             Ptr temp( p );
@@ -56,8 +56,8 @@ namespace Catch {
         const T* get() const{ return m_p; }
         T& operator*() const { return *m_p; }
         T* operator->() const { return m_p; }
-        bool operator !() const { return m_p == NULL; }
-        operator SafeBool::type() const { return SafeBool::makeSafe( m_p != NULL ); }
+        bool operator !() const { return m_p == CATCH_NULL; }
+        operator SafeBool::type() const { return SafeBool::makeSafe( m_p != CATCH_NULL ); }
 
     private:
         T* m_p;

--- a/include/internal/catch_registry_hub.hpp
+++ b/include/internal/catch_registry_hub.hpp
@@ -55,7 +55,7 @@ namespace Catch {
 
         // Single, global, instance
         inline RegistryHub*& getTheRegistryHub() {
-            static RegistryHub* theRegistryHub = NULL;
+            static RegistryHub* theRegistryHub = CATCH_NULL;
             if( !theRegistryHub )
                 theRegistryHub = new RegistryHub();
             return theRegistryHub;
@@ -70,7 +70,7 @@ namespace Catch {
     }
     void cleanUp() {
         delete getTheRegistryHub();
-        getTheRegistryHub() = NULL;
+        getTheRegistryHub() = CATCH_NULL;
         cleanUpContext();
     }
     std::string translateActiveException() {

--- a/include/internal/catch_reporter_registry.hpp
+++ b/include/internal/catch_reporter_registry.hpp
@@ -25,7 +25,7 @@ namespace Catch {
         virtual IStreamingReporter* create( std::string const& name, Ptr<IConfig> const& config ) const {
             FactoryMap::const_iterator it =  m_factories.find( name );
             if( it == m_factories.end() )
-                return NULL;
+                return CATCH_NULL;
             return it->second->create( ReporterConfig( config ) );
         }
 

--- a/include/internal/catch_result_builder.h
+++ b/include/internal/catch_result_builder.h
@@ -38,7 +38,8 @@ namespace Catch {
         ResultBuilder(  char const* macroName,
                         SourceLineInfo const& lineInfo,
                         char const* capturedExpression,
-                        ResultDisposition::Flags resultDisposition );
+                        ResultDisposition::Flags resultDisposition,
+                        char const* secondArg = "" );
 
         template<typename T>
         ExpressionLhs<T const&> operator <= ( T const& operand );
@@ -67,6 +68,8 @@ namespace Catch {
         void useActiveException( ResultDisposition::Flags resultDisposition = ResultDisposition::Normal );
         void captureResult( ResultWas::OfType resultType );
         void captureExpression();
+        void captureExpectedException( std::string const& expectedMessage );
+        void handleResult( AssertionResult const& result );
         void react();
         bool shouldDebugBreak() const;
         bool allowThrows() const;

--- a/include/internal/catch_result_builder.h
+++ b/include/internal/catch_result_builder.h
@@ -11,6 +11,7 @@
 #include "catch_result_type.h"
 #include "catch_assertionresult.h"
 #include "catch_common.h"
+#include "catch_matchers.hpp"
 
 namespace Catch {
 
@@ -69,6 +70,7 @@ namespace Catch {
         void captureResult( ResultWas::OfType resultType );
         void captureExpression();
         void captureExpectedException( std::string const& expectedMessage );
+        void captureExpectedException( Matchers::Impl::Matcher<std::string> const& matcher );
         void handleResult( AssertionResult const& result );
         void react();
         bool shouldDebugBreak() const;

--- a/include/internal/catch_result_builder.hpp
+++ b/include/internal/catch_result_builder.hpp
@@ -14,7 +14,7 @@
 #include "catch_interfaces_runner.h"
 #include "catch_interfaces_capture.h"
 #include "catch_interfaces_registry_hub.h"
-
+#include "catch_wildcard_pattern.hpp"
 
 namespace Catch {
 
@@ -78,7 +78,8 @@ namespace Catch {
         if( expectedMessage != "" ) {
             
             std::string actualMessage = Catch::translateActiveException();
-            if( expectedMessage != actualMessage ) {
+            WildcardPattern pattern( expectedMessage, WildcardPattern::CaseInsensitive );
+            if( !pattern.matches( actualMessage ) ) {
                 data.resultType = ResultWas::ExpressionFailed;
                 data.reconstructedExpression = actualMessage;
             }

--- a/include/internal/catch_runner_impl.hpp
+++ b/include/internal/catch_runner_impl.hpp
@@ -259,6 +259,8 @@ namespace Catch {
                 m_lastAssertionInfo = AssertionInfo( "TEST_CASE", testCaseInfo.lineInfo, "", ResultDisposition::Normal );
                 TestCaseTracker::Guard guard( *m_testCaseTracker );
 
+                seedRng( *m_config );
+                
                 Timer timer;
                 timer.start();
                 if( m_reporter->getPreferences().shouldRedirectStdOut ) {

--- a/include/internal/catch_runner_impl.hpp
+++ b/include/internal/catch_runner_impl.hpp
@@ -62,7 +62,7 @@ namespace Catch {
         explicit RunContext( Ptr<IConfig const> const& config, Ptr<IStreamingReporter> const& reporter )
         :   m_runInfo( config->name() ),
             m_context( getCurrentMutableContext() ),
-            m_activeTestCase( NULL ),
+            m_activeTestCase( CATCH_NULL ),
             m_config( config ),
             m_reporter( reporter ),
             m_prevRunner( m_context.getRunner() ),
@@ -78,7 +78,7 @@ namespace Catch {
         virtual ~RunContext() {
             m_reporter->testRunEnded( TestRunStats( m_runInfo, m_totals, aborting() ) );
             m_context.setRunner( m_prevRunner );
-            m_context.setConfig( NULL );
+            m_context.setConfig( CATCH_NULL );
             m_context.setResultCapture( m_prevResultCapture );
             m_context.setConfig( m_prevConfig );
         }
@@ -119,7 +119,7 @@ namespace Catch {
                                                         redirectedCerr,
                                                         aborting() ) );
 
-            m_activeTestCase = NULL;
+            m_activeTestCase = CATCH_NULL;
             m_testCaseTracker.reset();
 
             return deltaTotals;

--- a/include/internal/catch_runner_impl.hpp
+++ b/include/internal/catch_runner_impl.hpp
@@ -59,11 +59,11 @@ namespace Catch {
 
     public:
 
-        explicit RunContext( Ptr<IConfig const> const& config, Ptr<IStreamingReporter> const& reporter )
-        :   m_runInfo( config->name() ),
+        explicit RunContext( Ptr<IConfig const> const& _config, Ptr<IStreamingReporter> const& reporter )
+        :   m_runInfo( _config->name() ),
             m_context( getCurrentMutableContext() ),
             m_activeTestCase( CATCH_NULL ),
-            m_config( config ),
+            m_config( _config ),
             m_reporter( reporter ),
             m_prevRunner( m_context.getRunner() ),
             m_prevResultCapture( m_context.getResultCapture() ),

--- a/include/internal/catch_runner_impl.hpp
+++ b/include/internal/catch_runner_impl.hpp
@@ -78,7 +78,7 @@ namespace Catch {
         virtual ~RunContext() {
             m_reporter->testRunEnded( TestRunStats( m_runInfo, m_totals, aborting() ) );
             m_context.setRunner( m_prevRunner );
-            m_context.setConfig( CATCH_NULL );
+            m_context.setConfig( Ptr<IConfig const>() );
             m_context.setResultCapture( m_prevResultCapture );
             m_context.setConfig( m_prevConfig );
         }

--- a/include/internal/catch_section_info.hpp
+++ b/include/internal/catch_section_info.hpp
@@ -36,7 +36,7 @@ namespace Catch {
 
         RunningSection( std::string const& name )
         :   m_state( Root ),
-            m_parent( NULL ),
+            m_parent( CATCH_NULL ),
             m_name( name )
         {}
 

--- a/include/internal/catch_stream.hpp
+++ b/include/internal/catch_stream.hpp
@@ -65,7 +65,7 @@ namespace Catch {
     };
 
     Stream::Stream()
-    : streamBuf( NULL ), isOwned( false )
+    : streamBuf( CATCH_NULL ), isOwned( false )
     {}
 
     Stream::Stream( std::streambuf* _streamBuf, bool _isOwned )
@@ -75,7 +75,7 @@ namespace Catch {
     void Stream::release() {
         if( isOwned ) {
             delete streamBuf;
-            streamBuf = NULL;
+            streamBuf = CATCH_NULL;
             isOwned = false;
         }
     }

--- a/include/internal/catch_test_case_info.h
+++ b/include/internal/catch_test_case_info.h
@@ -40,6 +40,8 @@ namespace Catch {
 
         TestCaseInfo( TestCaseInfo const& other );
 
+        friend void setTags( TestCaseInfo& testCaseInfo, std::set<std::string> const& tags );
+        
         bool isHidden() const;
         bool throws() const;
         bool okToFail() const;

--- a/include/internal/catch_test_case_info.hpp
+++ b/include/internal/catch_test_case_info.hpp
@@ -88,11 +88,26 @@ namespace Catch {
             tags.insert( "hide" );
             tags.insert( "." );
         }
-
+        
         TestCaseInfo info( _name, _className, desc, tags, _lineInfo );
         return TestCase( _testCase, info );
     }
 
+    void setTags( TestCaseInfo& testCaseInfo, std::set<std::string> const& tags )
+    {
+        testCaseInfo.tags = tags;
+        testCaseInfo.lcaseTags.clear();
+        
+        std::ostringstream oss;
+        for( std::set<std::string>::const_iterator it = tags.begin(), itEnd = tags.end(); it != itEnd; ++it ) {
+            oss << "[" << *it << "]";
+            std::string lcaseTag = toLower( *it );
+            testCaseInfo.properties = static_cast<TestCaseInfo::SpecialProperties>( testCaseInfo.properties | parseSpecialTag( lcaseTag ) );
+            testCaseInfo.lcaseTags.insert( lcaseTag );
+        }
+        testCaseInfo.tagsAsString = oss.str();
+    }
+    
     TestCaseInfo::TestCaseInfo( std::string const& _name,
                                 std::string const& _className,
                                 std::string const& _description,
@@ -101,18 +116,10 @@ namespace Catch {
     :   name( _name ),
         className( _className ),
         description( _description ),
-        tags( _tags ),
         lineInfo( _lineInfo ),
         properties( None )
     {
-        std::ostringstream oss;
-        for( std::set<std::string>::const_iterator it = _tags.begin(), itEnd = _tags.end(); it != itEnd; ++it ) {
-            oss << "[" << *it << "]";
-            std::string lcaseTag = toLower( *it );
-            properties = static_cast<SpecialProperties>( properties | parseSpecialTag( lcaseTag ) );
-            lcaseTags.insert( lcaseTag );
-        }
-        tagsAsString = oss.str();
+        setTags( *this, _tags );
     }
 
     TestCaseInfo::TestCaseInfo( TestCaseInfo const& other )

--- a/include/internal/catch_test_case_registry_impl.hpp
+++ b/include/internal/catch_test_case_registry_impl.hpp
@@ -90,6 +90,8 @@ namespace Catch {
                     break;
                 case RunTests::InRandomOrder:
                 {
+                    seedRng( config );
+                    
                     RandomNumberGenerator rng;
                     std::random_shuffle( matchingTestCases.begin(), matchingTestCases.end(), rng );
                 }

--- a/include/internal/catch_test_case_registry_impl.hpp
+++ b/include/internal/catch_test_case_registry_impl.hpp
@@ -105,6 +105,7 @@ namespace Catch {
         std::vector<TestCase> m_functionsInOrder;
         std::vector<TestCase> m_nonHiddenFunctions;
         size_t m_unnamedCount;
+        std::ios_base::Init m_ostreamInit; // Forces cout/ cerr to be initialised
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/include/internal/catch_test_case_tracker.hpp
+++ b/include/internal/catch_test_case_tracker.hpp
@@ -8,6 +8,8 @@
 #ifndef TWOBLUECUBES_CATCH_TEST_CASE_TRACKER_HPP_INCLUDED
 #define TWOBLUECUBES_CATCH_TEST_CASE_TRACKER_HPP_INCLUDED
 
+#include "catch_compiler_capabilities.h"
+
 #include <map>
 #include <string>
 #include <assert.h>
@@ -60,7 +62,7 @@ namespace SectionTracking {
         TrackedSections::iterator it = m_children.find( childName );
         return it != m_children.end()
             ? &it->second
-            : NULL;
+            : CATCH_NULL;
     }
     inline TrackedSection* TrackedSection::acquireChild( std::string const& childName ) {
         if( TrackedSection* child = findChild( childName ) )
@@ -82,7 +84,7 @@ namespace SectionTracking {
     class TestCaseTracker {
     public:
         TestCaseTracker( std::string const& testCaseName )
-        :   m_testCase( testCaseName, NULL ),
+        :   m_testCase( testCaseName, CATCH_NULL ),
             m_currentSection( &m_testCase ),
             m_completedASectionThisRun( false )
         {}
@@ -99,7 +101,7 @@ namespace SectionTracking {
         void leaveSection() {
             m_currentSection->leave();
             m_currentSection = m_currentSection->getParent();
-            assert( m_currentSection != NULL );
+            assert( m_currentSection != CATCH_NULL );
             m_completedASectionThisRun = true;
         }
 

--- a/include/internal/catch_test_spec.hpp
+++ b/include/internal/catch_test_spec.hpp
@@ -13,63 +13,32 @@
 #pragma clang diagnostic ignored "-Wpadded"
 #endif
 
+#include "catch_wildcard_pattern.hpp"
 #include "catch_test_case_info.h"
 
 #include <string>
 #include <vector>
 
 namespace Catch {
-
+    
     class TestSpec {
         struct Pattern : SharedImpl<> {
             virtual ~Pattern();
             virtual bool matches( TestCaseInfo const& testCase ) const = 0;
         };
         class NamePattern : public Pattern {
-            enum WildcardPosition {
-                NoWildcard = 0,
-                WildcardAtStart = 1,
-                WildcardAtEnd = 2,
-                WildcardAtBothEnds = WildcardAtStart | WildcardAtEnd
-            };
-
         public:
-            NamePattern( std::string const& name ) : m_name( toLower( name ) ), m_wildcard( NoWildcard ) {
-                if( startsWith( m_name, "*" ) ) {
-                    m_name = m_name.substr( 1 );
-                    m_wildcard = WildcardAtStart;
-                }
-                if( endsWith( m_name, "*" ) ) {
-                    m_name = m_name.substr( 0, m_name.size()-1 );
-                    m_wildcard = static_cast<WildcardPosition>( m_wildcard | WildcardAtEnd );
-                }
-            }
+            NamePattern( std::string const& name )
+            : m_wildcardPattern( toLower( name ), WildcardPattern::CaseInsensitive )
+            {}
             virtual ~NamePattern();
             virtual bool matches( TestCaseInfo const& testCase ) const {
-                switch( m_wildcard ) {
-                    case NoWildcard:
-                        return m_name == toLower( testCase.name );
-                    case WildcardAtStart:
-                        return endsWith( toLower( testCase.name ), m_name );
-                    case WildcardAtEnd:
-                        return startsWith( toLower( testCase.name ), m_name );
-                    case WildcardAtBothEnds:
-                        return contains( toLower( testCase.name ), m_name );
-                }
-
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunreachable-code"
-#endif
-                throw std::logic_error( "Unknown enum" );
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+                return m_wildcardPattern.matches( toLower( testCase.name ) );
             }
         private:
-            std::string m_name;
-            WildcardPosition m_wildcard;
+            WildcardPattern m_wildcardPattern;
         };
+        
         class TagPattern : public Pattern {
         public:
             TagPattern( std::string const& tag ) : m_tag( toLower( tag ) ) {}
@@ -80,6 +49,7 @@ namespace Catch {
         private:
             std::string m_tag;
         };
+        
         class ExcludedPattern : public Pattern {
         public:
             ExcludedPattern( Ptr<Pattern> const& underlyingPattern ) : m_underlyingPattern( underlyingPattern ) {}

--- a/include/internal/catch_test_spec.hpp
+++ b/include/internal/catch_test_spec.hpp
@@ -29,7 +29,7 @@ namespace Catch {
         class NamePattern : public Pattern {
         public:
             NamePattern( std::string const& name )
-            : m_wildcardPattern( toLower( name ), WildcardPattern::CaseInsensitive )
+            : m_wildcardPattern( toLower( name ), CaseSensitive::No )
             {}
             virtual ~NamePattern();
             virtual bool matches( TestCaseInfo const& testCase ) const {

--- a/include/internal/catch_timer.hpp
+++ b/include/internal/catch_timer.hpp
@@ -37,7 +37,7 @@ namespace Catch {
 #else
         uint64_t getCurrentTicks() {
             timeval t;
-            gettimeofday(&t,NULL);
+            gettimeofday(&t,CATCH_NULL);
             return static_cast<uint64_t>( t.tv_sec ) * 1000000ull + static_cast<uint64_t>( t.tv_usec );
         }
 #endif

--- a/include/internal/catch_tostring.h
+++ b/include/internal/catch_tostring.h
@@ -52,6 +52,11 @@ std::string toString( char value );
 std::string toString( signed char value );
 std::string toString( unsigned char value );
 
+#ifdef CATCH_CONFIG_CPP11_LONG_LONG
+std::string toString( long long value );
+std::string toString( unsigned long long value );
+#endif
+
 #ifdef CATCH_CONFIG_CPP11_NULLPTR
 std::string toString( std::nullptr_t );
 #endif
@@ -65,7 +70,7 @@ std::string toString( std::nullptr_t );
   
 namespace Detail {
 
-    extern std::string unprintableString;
+    extern const std::string unprintableString;
 
     struct BorgType {
         template<typename T> BorgType( T const& );

--- a/include/internal/catch_tostring.h
+++ b/include/internal/catch_tostring.h
@@ -148,7 +148,7 @@ struct StringMaker<T*> {
     template<typename U>
     static std::string convert( U* p ) {
         if( !p )
-            return INTERNAL_CATCH_STRINGIFY( NULL );
+            return "NULL";
         else
             return Detail::rawMemoryToString( p );
     }
@@ -158,7 +158,7 @@ template<typename R, typename C>
 struct StringMaker<R C::*> {
     static std::string convert( R C::* p ) {
         if( !p )
-            return INTERNAL_CATCH_STRINGIFY( NULL );
+            return "NULL";
         else
             return Detail::rawMemoryToString( p );
     }

--- a/include/internal/catch_tostring.hpp
+++ b/include/internal/catch_tostring.hpp
@@ -15,9 +15,11 @@ namespace Catch {
 
 namespace Detail {
 
-    std::string unprintableString = "{?}";
-
+    const std::string unprintableString = "{?}";
+    
     namespace {
+        const int hexThreshold = 255;
+
         struct Endianness {
             enum Arch { Big, Little };
 
@@ -99,7 +101,7 @@ std::string toString( wchar_t* const value )
 std::string toString( int value ) {
     std::ostringstream oss;
     oss << value;
-    if( value >= 255 )
+    if( value > Detail::hexThreshold )
         oss << " (0x" << std::hex << value << ")";
     return oss.str();
 }
@@ -107,7 +109,7 @@ std::string toString( int value ) {
 std::string toString( unsigned long value ) {
     std::ostringstream oss;
     oss << value;
-    if( value >= 255 )
+    if( value > Detail::hexThreshold )
         oss << " (0x" << std::hex << value << ")";
     return oss.str();
 }
@@ -157,6 +159,23 @@ std::string toString( unsigned char value ) {
     return toString( static_cast<char>( value ) );
 }
 
+#ifdef CATCH_CONFIG_CPP11_LONG_LONG
+std::string toString( long long value ) {
+    std::ostringstream oss;
+    oss << value;
+    if( value > Detail::hexThreshold )
+        oss << " (0x" << std::hex << value << ")";
+    return oss.str();
+}
+std::string toString( unsigned long long value ) {
+    std::ostringstream oss;
+    oss << value;
+    if( value > Detail::hexThreshold )
+        oss << " (0x" << std::hex << value << ")";
+    return oss.str();
+}
+#endif
+    
 #ifdef CATCH_CONFIG_CPP11_NULLPTR
 std::string toString( std::nullptr_t ) {
     return "nullptr";

--- a/include/internal/catch_version.hpp
+++ b/include/internal/catch_version.hpp
@@ -37,7 +37,7 @@ namespace Catch {
         return os;
     }
 
-    Version libraryVersion( 1, 2, 1, "develop", 3 );
+    Version libraryVersion( 1, 2, 1, "develop", 4 );
 
 }
 

--- a/include/internal/catch_version.hpp
+++ b/include/internal/catch_version.hpp
@@ -37,7 +37,7 @@ namespace Catch {
         return os;
     }
 
-    Version libraryVersion( 1, 2, 1, "develop", 5 );
+    Version libraryVersion( 1, 2, 1, "develop", 6 );
 
 }
 

--- a/include/internal/catch_version.hpp
+++ b/include/internal/catch_version.hpp
@@ -37,7 +37,7 @@ namespace Catch {
         return os;
     }
 
-    Version libraryVersion( 1, 2, 1, "develop", 8 );
+    Version libraryVersion( 1, 2, 1, "develop", 9 );
 
 }
 

--- a/include/internal/catch_version.hpp
+++ b/include/internal/catch_version.hpp
@@ -37,7 +37,7 @@ namespace Catch {
         return os;
     }
 
-    Version libraryVersion( 1, 2, 0, "", 0 );
+    Version libraryVersion( 1, 2, 1, "", 0 );
 
 }
 

--- a/include/internal/catch_version.hpp
+++ b/include/internal/catch_version.hpp
@@ -37,7 +37,7 @@ namespace Catch {
         return os;
     }
 
-    Version libraryVersion( 1, 2, 1, "develop", 2 );
+    Version libraryVersion( 1, 2, 1, "develop", 3 );
 
 }
 

--- a/include/internal/catch_version.hpp
+++ b/include/internal/catch_version.hpp
@@ -37,7 +37,7 @@ namespace Catch {
         return os;
     }
 
-    Version libraryVersion( 1, 2, 1, "develop", 6 );
+    Version libraryVersion( 1, 2, 1, "develop", 7 );
 
 }
 

--- a/include/internal/catch_version.hpp
+++ b/include/internal/catch_version.hpp
@@ -37,7 +37,7 @@ namespace Catch {
         return os;
     }
 
-    Version libraryVersion( 1, 2, 1, "", 0 );
+    Version libraryVersion( 1, 2, 1, "develop", 1 );
 
 }
 

--- a/include/internal/catch_version.hpp
+++ b/include/internal/catch_version.hpp
@@ -37,7 +37,7 @@ namespace Catch {
         return os;
     }
 
-    Version libraryVersion( 1, 2, 1, "develop", 9 );
+    Version libraryVersion( 1, 2, 1, "develop", 10 );
 
 }
 

--- a/include/internal/catch_version.hpp
+++ b/include/internal/catch_version.hpp
@@ -37,7 +37,7 @@ namespace Catch {
         return os;
     }
 
-    Version libraryVersion( 1, 2, 1, "develop", 4 );
+    Version libraryVersion( 1, 2, 1, "develop", 5 );
 
 }
 

--- a/include/internal/catch_version.hpp
+++ b/include/internal/catch_version.hpp
@@ -37,7 +37,7 @@ namespace Catch {
         return os;
     }
 
-    Version libraryVersion( 1, 2, 1, "develop", 7 );
+    Version libraryVersion( 1, 2, 1, "develop", 8 );
 
 }
 

--- a/include/internal/catch_version.hpp
+++ b/include/internal/catch_version.hpp
@@ -37,7 +37,7 @@ namespace Catch {
         return os;
     }
 
-    Version libraryVersion( 1, 2, 1, "develop", 1 );
+    Version libraryVersion( 1, 2, 1, "develop", 2 );
 
 }
 

--- a/include/internal/catch_wildcard_pattern.hpp
+++ b/include/internal/catch_wildcard_pattern.hpp
@@ -22,11 +22,7 @@ namespace Catch
         
     public:
         
-        enum CaseSensitivity {
-            CaseSensitive,
-            CaseInsensitive
-        };
-        WildcardPattern( std::string const& pattern, CaseSensitivity caseSensitivity )
+        WildcardPattern( std::string const& pattern, CaseSensitive::Choice caseSensitivity )
         :   m_caseSensitivity( caseSensitivity ),
             m_wildcard( NoWildcard ),
             m_pattern( adjustCase( pattern ) )
@@ -64,9 +60,9 @@ namespace Catch
         }
     private:
         std::string adjustCase( std::string const& str ) const {
-            return m_caseSensitivity == CaseInsensitive ? toLower( str ) : str;
+            return m_caseSensitivity == CaseSensitive::No ? toLower( str ) : str;
         }
-        CaseSensitivity m_caseSensitivity;
+        CaseSensitive::Choice m_caseSensitivity;
         WildcardPosition m_wildcard;
         std::string m_pattern;
     };

--- a/include/internal/catch_wildcard_pattern.hpp
+++ b/include/internal/catch_wildcard_pattern.hpp
@@ -1,0 +1,75 @@
+/*
+ *  Created by Phil on 13/7/2015.
+ *  Copyright 2015 Two Blue Cubes Ltd. All rights reserved.
+ *
+ *  Distributed under the Boost Software License, Version 1.0. (See accompanying
+ *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ */
+#ifndef TWOBLUECUBES_CATCH_WILDCARD_PATTERN_HPP_INCLUDED
+#define TWOBLUECUBES_CATCH_WILDCARD_PATTERN_HPP_INCLUDED
+
+#include "catch_common.h"
+
+namespace Catch
+{
+    class WildcardPattern {
+        enum WildcardPosition {
+            NoWildcard = 0,
+            WildcardAtStart = 1,
+            WildcardAtEnd = 2,
+            WildcardAtBothEnds = WildcardAtStart | WildcardAtEnd
+        };
+        
+    public:
+        
+        enum CaseSensitivity {
+            CaseSensitive,
+            CaseInsensitive
+        };
+        WildcardPattern( std::string const& pattern, CaseSensitivity caseSensitivity )
+        :   m_caseSensitivity( caseSensitivity ),
+            m_wildcard( NoWildcard ),
+            m_pattern( adjustCase( pattern ) )
+        {
+            if( startsWith( m_pattern, "*" ) ) {
+                m_pattern = m_pattern.substr( 1 );
+                m_wildcard = WildcardAtStart;
+            }
+            if( endsWith( m_pattern, "*" ) ) {
+                m_pattern = m_pattern.substr( 0, m_pattern.size()-1 );
+                m_wildcard = static_cast<WildcardPosition>( m_wildcard | WildcardAtEnd );
+            }
+        }
+        virtual ~WildcardPattern();
+        virtual bool matches( std::string const& str ) const {
+            switch( m_wildcard ) {
+                case NoWildcard:
+                    return m_pattern == adjustCase( str );
+                case WildcardAtStart:
+                    return endsWith( adjustCase( str ), m_pattern );
+                case WildcardAtEnd:
+                    return startsWith( adjustCase( str ), m_pattern );
+                case WildcardAtBothEnds:
+                    return contains( adjustCase( str ), m_pattern );
+            }
+            
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunreachable-code"
+#endif
+            throw std::logic_error( "Unknown enum" );
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+        }
+    private:
+        std::string adjustCase( std::string const& str ) const {
+            return m_caseSensitivity == CaseInsensitive ? toLower( str ) : str;
+        }
+        CaseSensitivity m_caseSensitivity;
+        WildcardPosition m_wildcard;
+        std::string m_pattern;
+    };
+}
+
+#endif // TWOBLUECUBES_CATCH_WILDCARD_PATTERN_HPP_INCLUDED

--- a/include/internal/catch_xmlwriter.hpp
+++ b/include/internal/catch_xmlwriter.hpp
@@ -8,7 +8,8 @@
 #ifndef TWOBLUECUBES_CATCH_XMLWRITER_HPP_INCLUDED
 #define TWOBLUECUBES_CATCH_XMLWRITER_HPP_INCLUDED
 
-#include "../internal/catch_stream.h"
+#include "catch_stream.h"
+#include "catch_compiler_capabilities.h"
 
 #include <sstream>
 #include <string>
@@ -27,7 +28,7 @@ namespace Catch {
 
             ScopedElement( ScopedElement const& other )
             :   m_writer( other.m_writer ){
-                other.m_writer = NULL;
+                other.m_writer = CATCH_NULL;
             }
 
             ~ScopedElement() {

--- a/include/internal/catch_xmlwriter.hpp
+++ b/include/internal/catch_xmlwriter.hpp
@@ -10,6 +10,7 @@
 
 #include "catch_stream.h"
 #include "catch_compiler_capabilities.h"
+#include "catch_suppress_warnings.h"
 
 #include <sstream>
 #include <string>
@@ -231,4 +232,6 @@ namespace Catch {
     };
 
 }
+#include "catch_reenable_warnings.h"
+
 #endif // TWOBLUECUBES_CATCH_XMLWRITER_HPP_INCLUDED

--- a/projects/SelfTest/Baselines/console.std.approved.txt
+++ b/projects/SelfTest/Baselines/console.std.approved.txt
@@ -798,5 +798,5 @@ with expansion:
 
 ===============================================================================
 test cases: 157 | 117 passed | 39 failed |  1 failed as expected
-assertions: 774 | 681 passed | 80 failed | 13 failed as expected
+assertions: 773 | 680 passed | 80 failed | 13 failed as expected
 

--- a/projects/SelfTest/Baselines/console.std.approved.txt
+++ b/projects/SelfTest/Baselines/console.std.approved.txt
@@ -398,7 +398,7 @@ due to unexpected exception with message:
   3.14
 
 -------------------------------------------------------------------------------
-Exception messages can be tested for
+Mismatching exception messages failing the test
 -------------------------------------------------------------------------------
 ExceptionTests.cpp:<line number>
 ...............................................................................
@@ -797,6 +797,6 @@ with expansion:
   "first" == "second"
 
 ===============================================================================
-test cases: 156 | 116 passed | 39 failed |  1 failed as expected
-assertions: 767 | 674 passed | 80 failed | 13 failed as expected
+test cases: 157 | 117 passed | 39 failed |  1 failed as expected
+assertions: 774 | 681 passed | 80 failed | 13 failed as expected
 

--- a/projects/SelfTest/Baselines/console.std.approved.txt
+++ b/projects/SelfTest/Baselines/console.std.approved.txt
@@ -797,6 +797,6 @@ with expansion:
   "first" == "second"
 
 ===============================================================================
-test cases: 158 | 118 passed | 39 failed |  1 failed as expected
-assertions: 783 | 690 passed | 80 failed | 13 failed as expected
+test cases: 159 | 119 passed | 39 failed |  1 failed as expected
+assertions: 784 | 691 passed | 80 failed | 13 failed as expected
 

--- a/projects/SelfTest/Baselines/console.std.approved.txt
+++ b/projects/SelfTest/Baselines/console.std.approved.txt
@@ -797,6 +797,6 @@ with expansion:
   "first" == "second"
 
 ===============================================================================
-test cases: 157 | 117 passed | 39 failed |  1 failed as expected
-assertions: 773 | 680 passed | 80 failed | 13 failed as expected
+test cases: 158 | 118 passed | 39 failed |  1 failed as expected
+assertions: 783 | 690 passed | 80 failed | 13 failed as expected
 

--- a/projects/SelfTest/Baselines/console.std.approved.txt
+++ b/projects/SelfTest/Baselines/console.std.approved.txt
@@ -398,6 +398,17 @@ due to unexpected exception with message:
   3.14
 
 -------------------------------------------------------------------------------
+Exception messages can be tested for
+-------------------------------------------------------------------------------
+ExceptionTests.cpp:<line number>
+...............................................................................
+
+ExceptionTests.cpp:<line number>: FAILED:
+  REQUIRE_THROWS_WITH( thisThrows(), "should fail" )
+with expansion:
+  expected exception
+
+-------------------------------------------------------------------------------
 INFO and WARN do not abort tests
 -------------------------------------------------------------------------------
 MessageTests.cpp:<line number>
@@ -786,6 +797,6 @@ with expansion:
   "first" == "second"
 
 ===============================================================================
-test cases: 155 | 116 passed | 38 failed |  1 failed as expected
-assertions: 765 | 673 passed | 79 failed | 13 failed as expected
+test cases: 156 | 116 passed | 39 failed |  1 failed as expected
+assertions: 767 | 674 passed | 80 failed | 13 failed as expected
 

--- a/projects/SelfTest/Baselines/console.sw.approved.txt
+++ b/projects/SelfTest/Baselines/console.sw.approved.txt
@@ -1278,6 +1278,21 @@ PASSED:
   REQUIRE_THROWS( thisFunctionNotImplemented( 7 ) )
 
 -------------------------------------------------------------------------------
+Exception messages can be tested for
+-------------------------------------------------------------------------------
+ExceptionTests.cpp:<line number>
+...............................................................................
+
+ExceptionTests.cpp:<line number>:
+PASSED:
+  REQUIRE_THROWS_WITH( thisThrows(), "expected exception" )
+
+ExceptionTests.cpp:<line number>: FAILED:
+  REQUIRE_THROWS_WITH( thisThrows(), "should fail" )
+with expansion:
+  expected exception
+
+-------------------------------------------------------------------------------
 Generators over two ranges
 -------------------------------------------------------------------------------
 GeneratorTests.cpp:<line number>
@@ -7944,6 +7959,6 @@ with expansion:
   true
 
 ===============================================================================
-test cases: 155 | 100 passed | 54 failed |  1 failed as expected
-assertions: 785 | 673 passed | 99 failed | 13 failed as expected
+test cases: 156 | 100 passed |  55 failed |  1 failed as expected
+assertions: 787 | 674 passed | 100 failed | 13 failed as expected
 

--- a/projects/SelfTest/Baselines/console.sw.approved.txt
+++ b/projects/SelfTest/Baselines/console.sw.approved.txt
@@ -846,9 +846,7 @@ ConditionTests.cpp:<line number>:
 PASSED:
   REQUIRE( (std::numeric_limits<unsigned long>::max)() > ul )
 with expansion:
-  18446744073709551615 (0x<hex digits>)
-  >
-  4
+  4294967295 (0x<hex digits>) > 4
 
 -------------------------------------------------------------------------------
 comparisons between int variables
@@ -3885,6 +3883,20 @@ with expansion:
   "[&#x7F]" == "[&#x7F]"
 
 -------------------------------------------------------------------------------
+long long
+-------------------------------------------------------------------------------
+MiscTests.cpp:<line number>
+...............................................................................
+
+MiscTests.cpp:<line number>:
+PASSED:
+  REQUIRE( l == std::numeric_limits<long long>::max() )
+with expansion:
+  9223372036854775807 (0x<hex digits>)
+  ==
+  9223372036854775807 (0x<hex digits>)
+
+-------------------------------------------------------------------------------
 Process can be configured on command line
   default - no arguments
 -------------------------------------------------------------------------------
@@ -6274,9 +6286,7 @@ TrickyTests.cpp:<line number>:
 PASSED:
   CHECK( m == &S::f )
 with expansion:
-  0x<hex digits>
-  ==
-  0x<hex digits>
+  0x<hex digits> == 0x<hex digits>
 
 -------------------------------------------------------------------------------
 pointer to class
@@ -8126,6 +8136,6 @@ with expansion:
   true
 
 ===============================================================================
-test cases: 158 | 102 passed |  55 failed |  1 failed as expected
-assertions: 803 | 690 passed | 100 failed | 13 failed as expected
+test cases: 159 | 103 passed |  55 failed |  1 failed as expected
+assertions: 804 | 691 passed | 100 failed | 13 failed as expected
 

--- a/projects/SelfTest/Baselines/console.sw.approved.txt
+++ b/projects/SelfTest/Baselines/console.sw.approved.txt
@@ -973,51 +973,51 @@ ConditionTests.cpp:<line number>
 
 ConditionTests.cpp:<line number>:
 PASSED:
-  REQUIRE( p == __null )
+  REQUIRE( p == nullptr )
 with expansion:
-  __null == 0
+  NULL == nullptr
 
 ConditionTests.cpp:<line number>:
 PASSED:
   REQUIRE( p == pNULL )
 with expansion:
-  __null == __null
+  NULL == NULL
 
 ConditionTests.cpp:<line number>:
 PASSED:
-  REQUIRE( p != __null )
+  REQUIRE( p != nullptr )
 with expansion:
-  0x<hex digits> != 0
+  0x<hex digits> != nullptr
 
 ConditionTests.cpp:<line number>:
 PASSED:
-  REQUIRE( cp != __null )
+  REQUIRE( cp != nullptr )
 with expansion:
-  0x<hex digits> != 0
+  0x<hex digits> != nullptr
 
 ConditionTests.cpp:<line number>:
 PASSED:
-  REQUIRE( cpc != __null )
+  REQUIRE( cpc != nullptr )
 with expansion:
-  0x<hex digits> != 0
+  0x<hex digits> != nullptr
 
 ConditionTests.cpp:<line number>:
 PASSED:
-  REQUIRE( returnsNull() == __null )
+  REQUIRE( returnsNull() == nullptr )
 with expansion:
-  {null string} == 0
+  {null string} == nullptr
 
 ConditionTests.cpp:<line number>:
 PASSED:
-  REQUIRE( returnsConstNull() == __null )
+  REQUIRE( returnsConstNull() == nullptr )
 with expansion:
-  {null string} == 0
+  {null string} == nullptr
 
 ConditionTests.cpp:<line number>:
 PASSED:
-  REQUIRE( __null != p )
+  REQUIRE( nullptr != p )
 with expansion:
-  0 != 0x<hex digits>
+  nullptr != 0x<hex digits>
 
 -------------------------------------------------------------------------------
 'Not' checks that should succeed
@@ -3113,13 +3113,13 @@ MiscTests.cpp:<line number>
 
 MiscTests.cpp:<line number>:
 PASSED:
-  REQUIRE( makeString( false ) != static_cast<char*>(__null) )
+  REQUIRE( makeString( false ) != static_cast<char*>(nullptr) )
 with expansion:
   "valid string" != {null string}
 
 MiscTests.cpp:<line number>:
 PASSED:
-  REQUIRE( makeString( true ) == static_cast<char*>(__null) )
+  REQUIRE( makeString( true ) == static_cast<char*>(nullptr) )
 with expansion:
   {null string} == {null string}
 
@@ -3316,7 +3316,7 @@ MiscTests.cpp:<line number>
 
 MiscTests.cpp:<line number>:
 PASSED:
-  REQUIRE_THAT( "" Equals(__null) )
+  REQUIRE_THAT( "" Equals(nullptr) )
 with expansion:
   "" equals: ""
 
@@ -5863,9 +5863,9 @@ TrickyTests.cpp:<line number>
 
 TrickyTests.cpp:<line number>:
 PASSED:
-  REQUIRE( obj.prop != __null )
+  REQUIRE( obj.prop != nullptr )
 with expansion:
-  0x<hex digits> != 0
+  0x<hex digits> != nullptr
 
 -------------------------------------------------------------------------------
 (unimplemented) static bools can be evaluated
@@ -6106,7 +6106,7 @@ TrickyTests.cpp:<line number>:
 PASSED:
   REQUIRE( p == 0 )
 with expansion:
-  __null == 0
+  NULL == 0
 
 -------------------------------------------------------------------------------
 null_ptr
@@ -6118,7 +6118,7 @@ TrickyTests.cpp:<line number>:
 PASSED:
   REQUIRE( ptr.get() == nullptr )
 with expansion:
-  __null == nullptr
+  NULL == nullptr
 
 -------------------------------------------------------------------------------
 X/level/0/a

--- a/projects/SelfTest/Baselines/console.sw.approved.txt
+++ b/projects/SelfTest/Baselines/console.sw.approved.txt
@@ -3763,6 +3763,128 @@ with expansion:
   ""wide load"" == ""wide load""
 
 -------------------------------------------------------------------------------
+XmlEncode
+  normal string
+-------------------------------------------------------------------------------
+MiscTests.cpp:<line number>
+...............................................................................
+
+MiscTests.cpp:<line number>:
+PASSED:
+  REQUIRE( encode( "normal string" ) == "normal string" )
+with expansion:
+  "normal string" == "normal string"
+
+-------------------------------------------------------------------------------
+XmlEncode
+  empty string
+-------------------------------------------------------------------------------
+MiscTests.cpp:<line number>
+...............................................................................
+
+MiscTests.cpp:<line number>:
+PASSED:
+  REQUIRE( encode( "" ) == "" )
+with expansion:
+  "" == ""
+
+-------------------------------------------------------------------------------
+XmlEncode
+  string with ampersand
+-------------------------------------------------------------------------------
+MiscTests.cpp:<line number>
+...............................................................................
+
+MiscTests.cpp:<line number>:
+PASSED:
+  REQUIRE( encode( "smith & jones" ) == "smith &amp; jones" )
+with expansion:
+  "smith &amp; jones" == "smith &amp; jones"
+
+-------------------------------------------------------------------------------
+XmlEncode
+  string with less-than
+-------------------------------------------------------------------------------
+MiscTests.cpp:<line number>
+...............................................................................
+
+MiscTests.cpp:<line number>:
+PASSED:
+  REQUIRE( encode( "smith < jones" ) == "smith &lt; jones" )
+with expansion:
+  "smith &lt; jones" == "smith &lt; jones"
+
+-------------------------------------------------------------------------------
+XmlEncode
+  string with greater-than
+-------------------------------------------------------------------------------
+MiscTests.cpp:<line number>
+...............................................................................
+
+MiscTests.cpp:<line number>:
+PASSED:
+  REQUIRE( encode( "smith > jones" ) == "smith > jones" )
+with expansion:
+  "smith > jones" == "smith > jones"
+
+MiscTests.cpp:<line number>:
+PASSED:
+  REQUIRE( encode( "smith ]]> jones" ) == "smith ]]&gt; jones" )
+with expansion:
+  "smith ]]&gt; jones"
+  ==
+  "smith ]]&gt; jones"
+
+-------------------------------------------------------------------------------
+XmlEncode
+  string with quotes
+-------------------------------------------------------------------------------
+MiscTests.cpp:<line number>
+...............................................................................
+
+MiscTests.cpp:<line number>:
+PASSED:
+  REQUIRE( encode( stringWithQuotes ) == stringWithQuotes )
+with expansion:
+  "don't "quote" me on that"
+  ==
+  "don't "quote" me on that"
+
+MiscTests.cpp:<line number>:
+PASSED:
+  REQUIRE( encode( stringWithQuotes, Catch::XmlEncode::ForAttributes ) == "don't &quot;quote&quot; me on that" )
+with expansion:
+  "don't &quot;quote&quot; me on that"
+  ==
+  "don't &quot;quote&quot; me on that"
+
+-------------------------------------------------------------------------------
+XmlEncode
+  string with control char (1)
+-------------------------------------------------------------------------------
+MiscTests.cpp:<line number>
+...............................................................................
+
+MiscTests.cpp:<line number>:
+PASSED:
+  REQUIRE( encode( "[\x01]" ) == "[&#x1]" )
+with expansion:
+  "[&#x1]" == "[&#x1]"
+
+-------------------------------------------------------------------------------
+XmlEncode
+  string with control char (x7F)
+-------------------------------------------------------------------------------
+MiscTests.cpp:<line number>
+...............................................................................
+
+MiscTests.cpp:<line number>:
+PASSED:
+  REQUIRE( encode( "[\x7F]" ) == "[&#x7F]" )
+with expansion:
+  "[&#x7F]" == "[&#x7F]"
+
+-------------------------------------------------------------------------------
 Process can be configured on command line
   default - no arguments
 -------------------------------------------------------------------------------
@@ -8004,6 +8126,6 @@ with expansion:
   true
 
 ===============================================================================
-test cases: 157 | 101 passed |  55 failed |  1 failed as expected
-assertions: 793 | 680 passed | 100 failed | 13 failed as expected
+test cases: 158 | 102 passed |  55 failed |  1 failed as expected
+assertions: 803 | 690 passed | 100 failed | 13 failed as expected
 

--- a/projects/SelfTest/Baselines/console.sw.approved.txt
+++ b/projects/SelfTest/Baselines/console.sw.approved.txt
@@ -1279,9 +1279,58 @@ PASSED:
 
 -------------------------------------------------------------------------------
 Exception messages can be tested for
+  exact match
 -------------------------------------------------------------------------------
 ExceptionTests.cpp:<line number>
 ...............................................................................
+
+ExceptionTests.cpp:<line number>:
+PASSED:
+  REQUIRE_THROWS_WITH( thisThrows(), "expected exception" )
+
+-------------------------------------------------------------------------------
+Exception messages can be tested for
+  different case
+-------------------------------------------------------------------------------
+ExceptionTests.cpp:<line number>
+...............................................................................
+
+ExceptionTests.cpp:<line number>:
+PASSED:
+  REQUIRE_THROWS_WITH( thisThrows(), "expecteD Exception" )
+
+-------------------------------------------------------------------------------
+Exception messages can be tested for
+  wildcarded
+-------------------------------------------------------------------------------
+ExceptionTests.cpp:<line number>
+...............................................................................
+
+ExceptionTests.cpp:<line number>:
+PASSED:
+  REQUIRE_THROWS_WITH( thisThrows(), "expected*" )
+
+ExceptionTests.cpp:<line number>:
+PASSED:
+  REQUIRE_THROWS_WITH( thisThrows(), "*exception" )
+
+ExceptionTests.cpp:<line number>:
+PASSED:
+  REQUIRE_THROWS_WITH( thisThrows(), "*except*" )
+
+ExceptionTests.cpp:<line number>:
+PASSED:
+  REQUIRE_THROWS_WITH( thisThrows(), "*exCept*" )
+
+-------------------------------------------------------------------------------
+Mismatching exception messages failing the test
+-------------------------------------------------------------------------------
+ExceptionTests.cpp:<line number>
+...............................................................................
+
+ExceptionTests.cpp:<line number>:
+PASSED:
+  REQUIRE_THROWS_WITH( thisThrows(), "expected exception" )
 
 ExceptionTests.cpp:<line number>:
 PASSED:
@@ -7959,6 +8008,6 @@ with expansion:
   true
 
 ===============================================================================
-test cases: 156 | 100 passed |  55 failed |  1 failed as expected
-assertions: 787 | 674 passed | 100 failed | 13 failed as expected
+test cases: 157 | 101 passed |  55 failed |  1 failed as expected
+assertions: 794 | 681 passed | 100 failed | 13 failed as expected
 

--- a/projects/SelfTest/Baselines/console.sw.approved.txt
+++ b/projects/SelfTest/Baselines/console.sw.approved.txt
@@ -1297,7 +1297,7 @@ ExceptionTests.cpp:<line number>
 
 ExceptionTests.cpp:<line number>:
 PASSED:
-  REQUIRE_THROWS_WITH( thisThrows(), "expecteD Exception" )
+  REQUIRE_THROWS_WITH( thisThrows(), Equals( "expecteD Exception", Catch::CaseSensitive::No ) )
 
 -------------------------------------------------------------------------------
 Exception messages can be tested for
@@ -1308,29 +1308,25 @@ ExceptionTests.cpp:<line number>
 
 ExceptionTests.cpp:<line number>:
 PASSED:
-  REQUIRE_THROWS_WITH( thisThrows(), "expected*" )
+  REQUIRE_THROWS_WITH( thisThrows(), StartsWith( "expected" ) )
 
 ExceptionTests.cpp:<line number>:
 PASSED:
-  REQUIRE_THROWS_WITH( thisThrows(), "*exception" )
+  REQUIRE_THROWS_WITH( thisThrows(), EndsWith( "exception" ) )
 
 ExceptionTests.cpp:<line number>:
 PASSED:
-  REQUIRE_THROWS_WITH( thisThrows(), "*except*" )
+  REQUIRE_THROWS_WITH( thisThrows(), Contains( "except" ) )
 
 ExceptionTests.cpp:<line number>:
 PASSED:
-  REQUIRE_THROWS_WITH( thisThrows(), "*exCept*" )
+  REQUIRE_THROWS_WITH( thisThrows(), Contains( "exCept", Catch::CaseSensitive::No ) )
 
 -------------------------------------------------------------------------------
 Mismatching exception messages failing the test
 -------------------------------------------------------------------------------
 ExceptionTests.cpp:<line number>
 ...............................................................................
-
-ExceptionTests.cpp:<line number>:
-PASSED:
-  REQUIRE_THROWS_WITH( thisThrows(), "expected exception" )
 
 ExceptionTests.cpp:<line number>:
 PASSED:
@@ -8009,5 +8005,5 @@ with expansion:
 
 ===============================================================================
 test cases: 157 | 101 passed |  55 failed |  1 failed as expected
-assertions: 794 | 681 passed | 100 failed | 13 failed as expected
+assertions: 793 | 680 passed | 100 failed | 13 failed as expected
 

--- a/projects/SelfTest/Baselines/junit.sw.approved.txt
+++ b/projects/SelfTest/Baselines/junit.sw.approved.txt
@@ -1,5 +1,5 @@
 <testsuites>
-  <testsuite name="all tests" errors="12" failures="87" tests="785" hostname="tbd" time="{duration}" timestamp="tbd">
+  <testsuite name="all tests" errors="12" failures="88" tests="787" hostname="tbd" time="{duration}" timestamp="tbd">
     <testcase classname="global" name="toString(enum)" time="{duration}"/>
     <testcase classname="global" name="toString(enum w/operator&lt;&lt;)" time="{duration}"/>
     <testcase classname="global" name="toString(enum class)" time="{duration}"/>
@@ -251,6 +251,11 @@ ExceptionTests.cpp:<line number>
       </error>
     </testcase>
     <testcase classname="global" name="NotImplemented exception" time="{duration}"/>
+    <testcase classname="global" name="Exception messages can be tested for" time="{duration}">
+      <failure message="expected exception" type="REQUIRE_THROWS_WITH">
+ExceptionTests.cpp:<line number>
+      </failure>
+    </testcase>
     <testcase classname="global" name="Generators over two ranges" time="{duration}"/>
     <testcase classname="global" name="Generator over a range of pairs" time="{duration}"/>
     <testcase classname="global" name="INFO and WARN do not abort tests" time="{duration}"/>

--- a/projects/SelfTest/Baselines/junit.sw.approved.txt
+++ b/projects/SelfTest/Baselines/junit.sw.approved.txt
@@ -1,5 +1,5 @@
 <testsuites>
-  <testsuite name="all tests" errors="12" failures="88" tests="803" hostname="tbd" time="{duration}" timestamp="tbd">
+  <testsuite name="all tests" errors="12" failures="88" tests="804" hostname="tbd" time="{duration}" timestamp="tbd">
     <testcase classname="global" name="toString(enum)" time="{duration}"/>
     <testcase classname="global" name="toString(enum w/operator&lt;&lt;)" time="{duration}"/>
     <testcase classname="global" name="toString(enum class)" time="{duration}"/>
@@ -471,6 +471,7 @@ MiscTests.cpp:<line number>
     <testcase classname="XmlEncode" name="string with quotes" time="{duration}"/>
     <testcase classname="XmlEncode" name="string with control char (1)" time="{duration}"/>
     <testcase classname="XmlEncode" name="string with control char (x7F)" time="{duration}"/>
+    <testcase classname="global" name="long long" time="{duration}"/>
     <testcase classname="Process can be configured on command line" name="default - no arguments" time="{duration}"/>
     <testcase classname="Process can be configured on command line" name="test lists/1 test" time="{duration}"/>
     <testcase classname="Process can be configured on command line" name="test lists/Specify one test case exclusion using exclude:" time="{duration}"/>

--- a/projects/SelfTest/Baselines/junit.sw.approved.txt
+++ b/projects/SelfTest/Baselines/junit.sw.approved.txt
@@ -1,5 +1,5 @@
 <testsuites>
-  <testsuite name="all tests" errors="12" failures="88" tests="793" hostname="tbd" time="{duration}" timestamp="tbd">
+  <testsuite name="all tests" errors="12" failures="88" tests="803" hostname="tbd" time="{duration}" timestamp="tbd">
     <testcase classname="global" name="toString(enum)" time="{duration}"/>
     <testcase classname="global" name="toString(enum w/operator&lt;&lt;)" time="{duration}"/>
     <testcase classname="global" name="toString(enum class)" time="{duration}"/>
@@ -463,6 +463,14 @@ MiscTests.cpp:<line number>
     <testcase classname="global" name="toString on const wchar_t pointer returns the string contents" time="{duration}"/>
     <testcase classname="global" name="toString on wchar_t const pointer returns the string contents" time="{duration}"/>
     <testcase classname="global" name="toString on wchar_t returns the string contents" time="{duration}"/>
+    <testcase classname="XmlEncode" name="normal string" time="{duration}"/>
+    <testcase classname="XmlEncode" name="empty string" time="{duration}"/>
+    <testcase classname="XmlEncode" name="string with ampersand" time="{duration}"/>
+    <testcase classname="XmlEncode" name="string with less-than" time="{duration}"/>
+    <testcase classname="XmlEncode" name="string with greater-than" time="{duration}"/>
+    <testcase classname="XmlEncode" name="string with quotes" time="{duration}"/>
+    <testcase classname="XmlEncode" name="string with control char (1)" time="{duration}"/>
+    <testcase classname="XmlEncode" name="string with control char (x7F)" time="{duration}"/>
     <testcase classname="Process can be configured on command line" name="default - no arguments" time="{duration}"/>
     <testcase classname="Process can be configured on command line" name="test lists/1 test" time="{duration}"/>
     <testcase classname="Process can be configured on command line" name="test lists/Specify one test case exclusion using exclude:" time="{duration}"/>

--- a/projects/SelfTest/Baselines/junit.sw.approved.txt
+++ b/projects/SelfTest/Baselines/junit.sw.approved.txt
@@ -1,5 +1,5 @@
 <testsuites>
-  <testsuite name="all tests" errors="12" failures="88" tests="787" hostname="tbd" time="{duration}" timestamp="tbd">
+  <testsuite name="all tests" errors="12" failures="88" tests="794" hostname="tbd" time="{duration}" timestamp="tbd">
     <testcase classname="global" name="toString(enum)" time="{duration}"/>
     <testcase classname="global" name="toString(enum w/operator&lt;&lt;)" time="{duration}"/>
     <testcase classname="global" name="toString(enum class)" time="{duration}"/>
@@ -251,7 +251,10 @@ ExceptionTests.cpp:<line number>
       </error>
     </testcase>
     <testcase classname="global" name="NotImplemented exception" time="{duration}"/>
-    <testcase classname="global" name="Exception messages can be tested for" time="{duration}">
+    <testcase classname="Exception messages can be tested for" name="exact match" time="{duration}"/>
+    <testcase classname="Exception messages can be tested for" name="different case" time="{duration}"/>
+    <testcase classname="Exception messages can be tested for" name="wildcarded" time="{duration}"/>
+    <testcase classname="global" name="Mismatching exception messages failing the test" time="{duration}">
       <failure message="expected exception" type="REQUIRE_THROWS_WITH">
 ExceptionTests.cpp:<line number>
       </failure>

--- a/projects/SelfTest/Baselines/junit.sw.approved.txt
+++ b/projects/SelfTest/Baselines/junit.sw.approved.txt
@@ -1,5 +1,5 @@
 <testsuites>
-  <testsuite name="all tests" errors="12" failures="88" tests="794" hostname="tbd" time="{duration}" timestamp="tbd">
+  <testsuite name="all tests" errors="12" failures="88" tests="793" hostname="tbd" time="{duration}" timestamp="tbd">
     <testcase classname="global" name="toString(enum)" time="{duration}"/>
     <testcase classname="global" name="toString(enum w/operator&lt;&lt;)" time="{duration}"/>
     <testcase classname="global" name="toString(enum class)" time="{duration}"/>

--- a/projects/SelfTest/Baselines/xml.sw.approved.txt
+++ b/projects/SelfTest/Baselines/xml.sw.approved.txt
@@ -1611,10 +1611,10 @@
       <Section name="different case">
         <Expression success="true" type="REQUIRE_THROWS_WITH" filename="projects/SelfTest/ExceptionTests.cpp" >
           <Original>
-            thisThrows(), &quot;expecteD Exception&quot;
+            thisThrows(), Equals( &quot;expecteD Exception&quot;, Catch::CaseSensitive::No )
           </Original>
           <Expanded>
-            thisThrows(), &quot;expecteD Exception&quot;
+            thisThrows(), Equals( &quot;expecteD Exception&quot;, Catch::CaseSensitive::No )
           </Expanded>
         </Expression>
         <OverallResults successes="1" failures="0" expectedFailures="0"/>
@@ -1622,34 +1622,34 @@
       <Section name="wildcarded">
         <Expression success="true" type="REQUIRE_THROWS_WITH" filename="projects/SelfTest/ExceptionTests.cpp" >
           <Original>
-            thisThrows(), &quot;expected*&quot;
+            thisThrows(), StartsWith( &quot;expected&quot; )
           </Original>
           <Expanded>
-            thisThrows(), &quot;expected*&quot;
+            thisThrows(), StartsWith( &quot;expected&quot; )
           </Expanded>
         </Expression>
         <Expression success="true" type="REQUIRE_THROWS_WITH" filename="projects/SelfTest/ExceptionTests.cpp" >
           <Original>
-            thisThrows(), &quot;*exception&quot;
+            thisThrows(), EndsWith( &quot;exception&quot; )
           </Original>
           <Expanded>
-            thisThrows(), &quot;*exception&quot;
+            thisThrows(), EndsWith( &quot;exception&quot; )
           </Expanded>
         </Expression>
         <Expression success="true" type="REQUIRE_THROWS_WITH" filename="projects/SelfTest/ExceptionTests.cpp" >
           <Original>
-            thisThrows(), &quot;*except*&quot;
+            thisThrows(), Contains( &quot;except&quot; )
           </Original>
           <Expanded>
-            thisThrows(), &quot;*except*&quot;
+            thisThrows(), Contains( &quot;except&quot; )
           </Expanded>
         </Expression>
         <Expression success="true" type="REQUIRE_THROWS_WITH" filename="projects/SelfTest/ExceptionTests.cpp" >
           <Original>
-            thisThrows(), &quot;*exCept*&quot;
+            thisThrows(), Contains( &quot;exCept&quot;, Catch::CaseSensitive::No )
           </Original>
           <Expanded>
-            thisThrows(), &quot;*exCept*&quot;
+            thisThrows(), Contains( &quot;exCept&quot;, Catch::CaseSensitive::No )
           </Expanded>
         </Expression>
         <OverallResults successes="4" failures="0" expectedFailures="0"/>
@@ -1657,14 +1657,6 @@
       <OverallResult success="true"/>
     </TestCase>
     <TestCase name="Mismatching exception messages failing the test">
-      <Expression success="true" type="REQUIRE_THROWS_WITH" filename="projects/SelfTest/ExceptionTests.cpp" >
-        <Original>
-          thisThrows(), &quot;expected exception&quot;
-        </Original>
-        <Expanded>
-          thisThrows(), &quot;expected exception&quot;
-        </Expanded>
-      </Expression>
       <Expression success="true" type="REQUIRE_THROWS_WITH" filename="projects/SelfTest/ExceptionTests.cpp" >
         <Original>
           thisThrows(), &quot;expected exception&quot;
@@ -8307,7 +8299,7 @@ there&quot;
       </Section>
       <OverallResult success="true"/>
     </TestCase>
-    <OverallResults successes="681" failures="100" expectedFailures="13"/>
+    <OverallResults successes="680" failures="100" expectedFailures="13"/>
   </Group>
-  <OverallResults successes="681" failures="100" expectedFailures="13"/>
+  <OverallResults successes="680" failures="100" expectedFailures="13"/>
 </Catch>

--- a/projects/SelfTest/Baselines/xml.sw.approved.txt
+++ b/projects/SelfTest/Baselines/xml.sw.approved.txt
@@ -1597,6 +1597,74 @@
       <OverallResult success="true"/>
     </TestCase>
     <TestCase name="Exception messages can be tested for">
+      <Section name="exact match">
+        <Expression success="true" type="REQUIRE_THROWS_WITH" filename="projects/SelfTest/ExceptionTests.cpp" >
+          <Original>
+            thisThrows(), &quot;expected exception&quot;
+          </Original>
+          <Expanded>
+            thisThrows(), &quot;expected exception&quot;
+          </Expanded>
+        </Expression>
+        <OverallResults successes="1" failures="0" expectedFailures="0"/>
+      </Section>
+      <Section name="different case">
+        <Expression success="true" type="REQUIRE_THROWS_WITH" filename="projects/SelfTest/ExceptionTests.cpp" >
+          <Original>
+            thisThrows(), &quot;expecteD Exception&quot;
+          </Original>
+          <Expanded>
+            thisThrows(), &quot;expecteD Exception&quot;
+          </Expanded>
+        </Expression>
+        <OverallResults successes="1" failures="0" expectedFailures="0"/>
+      </Section>
+      <Section name="wildcarded">
+        <Expression success="true" type="REQUIRE_THROWS_WITH" filename="projects/SelfTest/ExceptionTests.cpp" >
+          <Original>
+            thisThrows(), &quot;expected*&quot;
+          </Original>
+          <Expanded>
+            thisThrows(), &quot;expected*&quot;
+          </Expanded>
+        </Expression>
+        <Expression success="true" type="REQUIRE_THROWS_WITH" filename="projects/SelfTest/ExceptionTests.cpp" >
+          <Original>
+            thisThrows(), &quot;*exception&quot;
+          </Original>
+          <Expanded>
+            thisThrows(), &quot;*exception&quot;
+          </Expanded>
+        </Expression>
+        <Expression success="true" type="REQUIRE_THROWS_WITH" filename="projects/SelfTest/ExceptionTests.cpp" >
+          <Original>
+            thisThrows(), &quot;*except*&quot;
+          </Original>
+          <Expanded>
+            thisThrows(), &quot;*except*&quot;
+          </Expanded>
+        </Expression>
+        <Expression success="true" type="REQUIRE_THROWS_WITH" filename="projects/SelfTest/ExceptionTests.cpp" >
+          <Original>
+            thisThrows(), &quot;*exCept*&quot;
+          </Original>
+          <Expanded>
+            thisThrows(), &quot;*exCept*&quot;
+          </Expanded>
+        </Expression>
+        <OverallResults successes="4" failures="0" expectedFailures="0"/>
+      </Section>
+      <OverallResult success="true"/>
+    </TestCase>
+    <TestCase name="Mismatching exception messages failing the test">
+      <Expression success="true" type="REQUIRE_THROWS_WITH" filename="projects/SelfTest/ExceptionTests.cpp" >
+        <Original>
+          thisThrows(), &quot;expected exception&quot;
+        </Original>
+        <Expanded>
+          thisThrows(), &quot;expected exception&quot;
+        </Expanded>
+      </Expression>
       <Expression success="true" type="REQUIRE_THROWS_WITH" filename="projects/SelfTest/ExceptionTests.cpp" >
         <Original>
           thisThrows(), &quot;expected exception&quot;
@@ -8239,7 +8307,7 @@ there&quot;
       </Section>
       <OverallResult success="true"/>
     </TestCase>
-    <OverallResults successes="674" failures="100" expectedFailures="13"/>
+    <OverallResults successes="681" failures="100" expectedFailures="13"/>
   </Group>
-  <OverallResults successes="674" failures="100" expectedFailures="13"/>
+  <OverallResults successes="681" failures="100" expectedFailures="13"/>
 </Catch>

--- a/projects/SelfTest/Baselines/xml.sw.approved.txt
+++ b/projects/SelfTest/Baselines/xml.sw.approved.txt
@@ -3,18 +3,18 @@
     <TestCase name="toString(enum)">
       <Expression success="true" type="CHECK" filename="projects/SelfTest/EnumToString.cpp" >
         <Original>
-          Catch::toString(e0) == &quot;0&quot;
+          Catch::toString(e0) == "0"
         </Original>
         <Expanded>
-          &quot;0&quot; == &quot;0&quot;
+          "0" == "0"
         </Expanded>
       </Expression>
       <Expression success="true" type="CHECK" filename="projects/SelfTest/EnumToString.cpp" >
         <Original>
-          Catch::toString(e1) == &quot;1&quot;
+          Catch::toString(e1) == "1"
         </Original>
         <Expanded>
-          &quot;1&quot; == &quot;1&quot;
+          "1" == "1"
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -22,18 +22,18 @@
     <TestCase name="toString(enum w/operator&lt;&lt;)">
       <Expression success="true" type="CHECK" filename="projects/SelfTest/EnumToString.cpp" >
         <Original>
-          Catch::toString(e0) == &quot;E2{0}&quot;
+          Catch::toString(e0) == "E2{0}"
         </Original>
         <Expanded>
-          &quot;E2{0}&quot; == &quot;E2{0}&quot;
+          "E2{0}" == "E2{0}"
         </Expanded>
       </Expression>
       <Expression success="true" type="CHECK" filename="projects/SelfTest/EnumToString.cpp" >
         <Original>
-          Catch::toString(e1) == &quot;E2{1}&quot;
+          Catch::toString(e1) == "E2{1}"
         </Original>
         <Expanded>
-          &quot;E2{1}&quot; == &quot;E2{1}&quot;
+          "E2{1}" == "E2{1}"
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -41,18 +41,18 @@
     <TestCase name="toString(enum class)">
       <Expression success="true" type="CHECK" filename="projects/SelfTest/EnumToString.cpp" >
         <Original>
-          Catch::toString(e0) == &quot;0&quot;
+          Catch::toString(e0) == "0"
         </Original>
         <Expanded>
-          &quot;0&quot; == &quot;0&quot;
+          "0" == "0"
         </Expanded>
       </Expression>
       <Expression success="true" type="CHECK" filename="projects/SelfTest/EnumToString.cpp" >
         <Original>
-          Catch::toString(e1) == &quot;1&quot;
+          Catch::toString(e1) == "1"
         </Original>
         <Expanded>
-          &quot;1&quot; == &quot;1&quot;
+          "1" == "1"
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -60,28 +60,28 @@
     <TestCase name="toString(enum class w/operator&lt;&lt;)">
       <Expression success="true" type="CHECK" filename="projects/SelfTest/EnumToString.cpp" >
         <Original>
-          Catch::toString(e0) == &quot;E2/V0&quot;
+          Catch::toString(e0) == "E2/V0"
         </Original>
         <Expanded>
-          &quot;E2/V0&quot; == &quot;E2/V0&quot;
+          "E2/V0" == "E2/V0"
         </Expanded>
       </Expression>
       <Expression success="true" type="CHECK" filename="projects/SelfTest/EnumToString.cpp" >
         <Original>
-          Catch::toString(e1) == &quot;E2/V1&quot;
+          Catch::toString(e1) == "E2/V1"
         </Original>
         <Expanded>
-          &quot;E2/V1&quot; == &quot;E2/V1&quot;
+          "E2/V1" == "E2/V1"
         </Expanded>
       </Expression>
       <Expression success="true" type="CHECK" filename="projects/SelfTest/EnumToString.cpp" >
         <Original>
-          Catch::toString(e3) == &quot;Unknown enum value 10&quot;
+          Catch::toString(e3) == "Unknown enum value 10"
         </Original>
         <Expanded>
-          &quot;Unknown enum value 10&quot;
+          "Unknown enum value 10"
 ==
-&quot;Unknown enum value 10&quot;
+"Unknown enum value 10"
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -326,10 +326,10 @@
     <TestCase name="A METHOD_AS_TEST_CASE based test run that succeeds">
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ClassTests.cpp" >
         <Original>
-          s == &quot;hello&quot;
+          s == "hello"
         </Original>
         <Expanded>
-          &quot;hello&quot; == &quot;hello&quot;
+          "hello" == "hello"
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -337,10 +337,10 @@
     <TestCase name="A METHOD_AS_TEST_CASE based test run that fails">
       <Expression success="false" type="REQUIRE" filename="projects/SelfTest/ClassTests.cpp" >
         <Original>
-          s == &quot;world&quot;
+          s == "world"
         </Original>
         <Expanded>
-          &quot;hello&quot; == &quot;world&quot;
+          "hello" == "world"
         </Expanded>
       </Expression>
       <OverallResult success="false"/>
@@ -394,18 +394,18 @@
       </Expression>
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ConditionTests.cpp" >
         <Original>
-          data.str_hello == &quot;hello&quot;
+          data.str_hello == "hello"
         </Original>
         <Expanded>
-          &quot;hello&quot; == &quot;hello&quot;
+          "hello" == "hello"
         </Expanded>
       </Expression>
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ConditionTests.cpp" >
         <Original>
-          &quot;hello&quot; == data.str_hello
+          "hello" == data.str_hello
         </Original>
         <Expanded>
-          &quot;hello&quot; == &quot;hello&quot;
+          "hello" == "hello"
         </Expanded>
       </Expression>
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ConditionTests.cpp" >
@@ -493,26 +493,26 @@
       </Expression>
       <Expression success="false" type="CHECK" filename="projects/SelfTest/ConditionTests.cpp" >
         <Original>
-          data.str_hello == &quot;goodbye&quot;
+          data.str_hello == "goodbye"
         </Original>
         <Expanded>
-          &quot;hello&quot; == &quot;goodbye&quot;
+          "hello" == "goodbye"
         </Expanded>
       </Expression>
       <Expression success="false" type="CHECK" filename="projects/SelfTest/ConditionTests.cpp" >
         <Original>
-          data.str_hello == &quot;hell&quot;
+          data.str_hello == "hell"
         </Original>
         <Expanded>
-          &quot;hello&quot; == &quot;hell&quot;
+          "hello" == "hell"
         </Expanded>
       </Expression>
       <Expression success="false" type="CHECK" filename="projects/SelfTest/ConditionTests.cpp" >
         <Original>
-          data.str_hello == &quot;hello1&quot;
+          data.str_hello == "hello1"
         </Original>
         <Expanded>
-          &quot;hello&quot; == &quot;hello1&quot;
+          "hello" == "hello1"
         </Expanded>
       </Expression>
       <Expression success="false" type="CHECK" filename="projects/SelfTest/ConditionTests.cpp" >
@@ -592,26 +592,26 @@
       </Expression>
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ConditionTests.cpp" >
         <Original>
-          data.str_hello != &quot;goodbye&quot;
+          data.str_hello != "goodbye"
         </Original>
         <Expanded>
-          &quot;hello&quot; != &quot;goodbye&quot;
+          "hello" != "goodbye"
         </Expanded>
       </Expression>
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ConditionTests.cpp" >
         <Original>
-          data.str_hello != &quot;hell&quot;
+          data.str_hello != "hell"
         </Original>
         <Expanded>
-          &quot;hello&quot; != &quot;hell&quot;
+          "hello" != "hell"
         </Expanded>
       </Expression>
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ConditionTests.cpp" >
         <Original>
-          data.str_hello != &quot;hello1&quot;
+          data.str_hello != "hello1"
         </Original>
         <Expanded>
-          &quot;hello&quot; != &quot;hello1&quot;
+          "hello" != "hello1"
         </Expanded>
       </Expression>
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ConditionTests.cpp" >
@@ -651,10 +651,10 @@
       </Expression>
       <Expression success="false" type="CHECK" filename="projects/SelfTest/ConditionTests.cpp" >
         <Original>
-          data.str_hello != &quot;hello&quot;
+          data.str_hello != "hello"
         </Original>
         <Expanded>
-          &quot;hello&quot; != &quot;hello&quot;
+          "hello" != "hello"
         </Expanded>
       </Expression>
       <Expression success="false" type="CHECK" filename="projects/SelfTest/ConditionTests.cpp" >
@@ -758,50 +758,50 @@
       </Expression>
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ConditionTests.cpp" >
         <Original>
-          data.str_hello &lt;= &quot;hello&quot;
+          data.str_hello &lt;= "hello"
         </Original>
         <Expanded>
-          &quot;hello&quot; &lt;= &quot;hello&quot;
+          "hello" &lt;= "hello"
         </Expanded>
       </Expression>
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ConditionTests.cpp" >
         <Original>
-          data.str_hello >= &quot;hello&quot;
+          data.str_hello >= "hello"
         </Original>
         <Expanded>
-          &quot;hello&quot; >= &quot;hello&quot;
+          "hello" >= "hello"
         </Expanded>
       </Expression>
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ConditionTests.cpp" >
         <Original>
-          data.str_hello &lt; &quot;hellp&quot;
+          data.str_hello &lt; "hellp"
         </Original>
         <Expanded>
-          &quot;hello&quot; &lt; &quot;hellp&quot;
+          "hello" &lt; "hellp"
         </Expanded>
       </Expression>
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ConditionTests.cpp" >
         <Original>
-          data.str_hello &lt; &quot;zebra&quot;
+          data.str_hello &lt; "zebra"
         </Original>
         <Expanded>
-          &quot;hello&quot; &lt; &quot;zebra&quot;
+          "hello" &lt; "zebra"
         </Expanded>
       </Expression>
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ConditionTests.cpp" >
         <Original>
-          data.str_hello > &quot;hellm&quot;
+          data.str_hello > "hellm"
         </Original>
         <Expanded>
-          &quot;hello&quot; > &quot;hellm&quot;
+          "hello" > "hellm"
         </Expanded>
       </Expression>
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ConditionTests.cpp" >
         <Original>
-          data.str_hello > &quot;a&quot;
+          data.str_hello > "a"
         </Original>
         <Expanded>
-          &quot;hello&quot; > &quot;a&quot;
+          "hello" > "a"
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -897,66 +897,66 @@
       </Expression>
       <Expression success="false" type="CHECK" filename="projects/SelfTest/ConditionTests.cpp" >
         <Original>
-          data.str_hello > &quot;hello&quot;
+          data.str_hello > "hello"
         </Original>
         <Expanded>
-          &quot;hello&quot; > &quot;hello&quot;
+          "hello" > "hello"
         </Expanded>
       </Expression>
       <Expression success="false" type="CHECK" filename="projects/SelfTest/ConditionTests.cpp" >
         <Original>
-          data.str_hello &lt; &quot;hello&quot;
+          data.str_hello &lt; "hello"
         </Original>
         <Expanded>
-          &quot;hello&quot; &lt; &quot;hello&quot;
+          "hello" &lt; "hello"
         </Expanded>
       </Expression>
       <Expression success="false" type="CHECK" filename="projects/SelfTest/ConditionTests.cpp" >
         <Original>
-          data.str_hello > &quot;hellp&quot;
+          data.str_hello > "hellp"
         </Original>
         <Expanded>
-          &quot;hello&quot; > &quot;hellp&quot;
+          "hello" > "hellp"
         </Expanded>
       </Expression>
       <Expression success="false" type="CHECK" filename="projects/SelfTest/ConditionTests.cpp" >
         <Original>
-          data.str_hello > &quot;z&quot;
+          data.str_hello > "z"
         </Original>
         <Expanded>
-          &quot;hello&quot; > &quot;z&quot;
+          "hello" > "z"
         </Expanded>
       </Expression>
       <Expression success="false" type="CHECK" filename="projects/SelfTest/ConditionTests.cpp" >
         <Original>
-          data.str_hello &lt; &quot;hellm&quot;
+          data.str_hello &lt; "hellm"
         </Original>
         <Expanded>
-          &quot;hello&quot; &lt; &quot;hellm&quot;
+          "hello" &lt; "hellm"
         </Expanded>
       </Expression>
       <Expression success="false" type="CHECK" filename="projects/SelfTest/ConditionTests.cpp" >
         <Original>
-          data.str_hello &lt; &quot;a&quot;
+          data.str_hello &lt; "a"
         </Original>
         <Expanded>
-          &quot;hello&quot; &lt; &quot;a&quot;
+          "hello" &lt; "a"
         </Expanded>
       </Expression>
       <Expression success="false" type="CHECK" filename="projects/SelfTest/ConditionTests.cpp" >
         <Original>
-          data.str_hello >= &quot;z&quot;
+          data.str_hello >= "z"
         </Original>
         <Expanded>
-          &quot;hello&quot; >= &quot;z&quot;
+          "hello" >= "z"
         </Expanded>
       </Expression>
       <Expression success="false" type="CHECK" filename="projects/SelfTest/ConditionTests.cpp" >
         <Original>
-          data.str_hello &lt;= &quot;a&quot;
+          data.str_hello &lt;= "a"
         </Original>
         <Expanded>
-          &quot;hello&quot; &lt;= &quot;a&quot;
+          "hello" &lt;= "a"
         </Expanded>
       </Expression>
       <OverallResult success="false"/>
@@ -1600,10 +1600,10 @@
       <Section name="exact match">
         <Expression success="true" type="REQUIRE_THROWS_WITH" filename="projects/SelfTest/ExceptionTests.cpp" >
           <Original>
-            thisThrows(), &quot;expected exception&quot;
+            thisThrows(), "expected exception"
           </Original>
           <Expanded>
-            thisThrows(), &quot;expected exception&quot;
+            thisThrows(), "expected exception"
           </Expanded>
         </Expression>
         <OverallResults successes="1" failures="0" expectedFailures="0"/>
@@ -1611,10 +1611,10 @@
       <Section name="different case">
         <Expression success="true" type="REQUIRE_THROWS_WITH" filename="projects/SelfTest/ExceptionTests.cpp" >
           <Original>
-            thisThrows(), Equals( &quot;expecteD Exception&quot;, Catch::CaseSensitive::No )
+            thisThrows(), Equals( "expecteD Exception", Catch::CaseSensitive::No )
           </Original>
           <Expanded>
-            thisThrows(), Equals( &quot;expecteD Exception&quot;, Catch::CaseSensitive::No )
+            thisThrows(), Equals( "expecteD Exception", Catch::CaseSensitive::No )
           </Expanded>
         </Expression>
         <OverallResults successes="1" failures="0" expectedFailures="0"/>
@@ -1622,34 +1622,34 @@
       <Section name="wildcarded">
         <Expression success="true" type="REQUIRE_THROWS_WITH" filename="projects/SelfTest/ExceptionTests.cpp" >
           <Original>
-            thisThrows(), StartsWith( &quot;expected&quot; )
+            thisThrows(), StartsWith( "expected" )
           </Original>
           <Expanded>
-            thisThrows(), StartsWith( &quot;expected&quot; )
+            thisThrows(), StartsWith( "expected" )
           </Expanded>
         </Expression>
         <Expression success="true" type="REQUIRE_THROWS_WITH" filename="projects/SelfTest/ExceptionTests.cpp" >
           <Original>
-            thisThrows(), EndsWith( &quot;exception&quot; )
+            thisThrows(), EndsWith( "exception" )
           </Original>
           <Expanded>
-            thisThrows(), EndsWith( &quot;exception&quot; )
+            thisThrows(), EndsWith( "exception" )
           </Expanded>
         </Expression>
         <Expression success="true" type="REQUIRE_THROWS_WITH" filename="projects/SelfTest/ExceptionTests.cpp" >
           <Original>
-            thisThrows(), Contains( &quot;except&quot; )
+            thisThrows(), Contains( "except" )
           </Original>
           <Expanded>
-            thisThrows(), Contains( &quot;except&quot; )
+            thisThrows(), Contains( "except" )
           </Expanded>
         </Expression>
         <Expression success="true" type="REQUIRE_THROWS_WITH" filename="projects/SelfTest/ExceptionTests.cpp" >
           <Original>
-            thisThrows(), Contains( &quot;exCept&quot;, Catch::CaseSensitive::No )
+            thisThrows(), Contains( "exCept", Catch::CaseSensitive::No )
           </Original>
           <Expanded>
-            thisThrows(), Contains( &quot;exCept&quot;, Catch::CaseSensitive::No )
+            thisThrows(), Contains( "exCept", Catch::CaseSensitive::No )
           </Expanded>
         </Expression>
         <OverallResults successes="4" failures="0" expectedFailures="0"/>
@@ -1659,15 +1659,15 @@
     <TestCase name="Mismatching exception messages failing the test">
       <Expression success="true" type="REQUIRE_THROWS_WITH" filename="projects/SelfTest/ExceptionTests.cpp" >
         <Original>
-          thisThrows(), &quot;expected exception&quot;
+          thisThrows(), "expected exception"
         </Original>
         <Expanded>
-          thisThrows(), &quot;expected exception&quot;
+          thisThrows(), "expected exception"
         </Expanded>
       </Expression>
       <Expression success="false" type="REQUIRE_THROWS_WITH" filename="projects/SelfTest/ExceptionTests.cpp" >
         <Original>
-          thisThrows(), &quot;should fail&quot;
+          thisThrows(), "should fail"
         </Original>
         <Expanded>
           expected exception
@@ -3308,7 +3308,7 @@
           makeString( false ) != static_cast&lt;char*>(nullptr)
         </Original>
         <Expanded>
-          &quot;valid string&quot; != {null string}
+          "valid string" != {null string}
         </Expanded>
       </Expression>
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/MiscTests.cpp" >
@@ -3434,34 +3434,34 @@
     <TestCase name="String matchers">
       <Expression success="true" type="REQUIRE_THAT" filename="projects/SelfTest/MiscTests.cpp" >
         <Original>
-          testStringForMatching() Contains( &quot;string&quot; )
+          testStringForMatching() Contains( "string" )
         </Original>
         <Expanded>
-          &quot;this string contains 'abc' as a substring&quot; contains: &quot;string&quot;
+          "this string contains 'abc' as a substring" contains: "string"
         </Expanded>
       </Expression>
       <Expression success="true" type="CHECK_THAT" filename="projects/SelfTest/MiscTests.cpp" >
         <Original>
-          testStringForMatching() Contains( &quot;abc&quot; )
+          testStringForMatching() Contains( "abc" )
         </Original>
         <Expanded>
-          &quot;this string contains 'abc' as a substring&quot; contains: &quot;abc&quot;
+          "this string contains 'abc' as a substring" contains: "abc"
         </Expanded>
       </Expression>
       <Expression success="true" type="CHECK_THAT" filename="projects/SelfTest/MiscTests.cpp" >
         <Original>
-          testStringForMatching() StartsWith( &quot;this&quot; )
+          testStringForMatching() StartsWith( "this" )
         </Original>
         <Expanded>
-          &quot;this string contains 'abc' as a substring&quot; starts with: &quot;this&quot;
+          "this string contains 'abc' as a substring" starts with: "this"
         </Expanded>
       </Expression>
       <Expression success="true" type="CHECK_THAT" filename="projects/SelfTest/MiscTests.cpp" >
         <Original>
-          testStringForMatching() EndsWith( &quot;substring&quot; )
+          testStringForMatching() EndsWith( "substring" )
         </Original>
         <Expanded>
-          &quot;this string contains 'abc' as a substring&quot; ends with: &quot;substring&quot;
+          "this string contains 'abc' as a substring" ends with: "substring"
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -3469,10 +3469,10 @@
     <TestCase name="Contains string matcher">
       <Expression success="false" type="CHECK_THAT" filename="projects/SelfTest/MiscTests.cpp" >
         <Original>
-          testStringForMatching() Contains( &quot;not there&quot; )
+          testStringForMatching() Contains( "not there" )
         </Original>
         <Expanded>
-          &quot;this string contains 'abc' as a substring&quot; contains: &quot;not there&quot;
+          "this string contains 'abc' as a substring" contains: "not there"
         </Expanded>
       </Expression>
       <OverallResult success="false"/>
@@ -3480,10 +3480,10 @@
     <TestCase name="StartsWith string matcher">
       <Expression success="false" type="CHECK_THAT" filename="projects/SelfTest/MiscTests.cpp" >
         <Original>
-          testStringForMatching() StartsWith( &quot;string&quot; )
+          testStringForMatching() StartsWith( "string" )
         </Original>
         <Expanded>
-          &quot;this string contains 'abc' as a substring&quot; starts with: &quot;string&quot;
+          "this string contains 'abc' as a substring" starts with: "string"
         </Expanded>
       </Expression>
       <OverallResult success="false"/>
@@ -3491,10 +3491,10 @@
     <TestCase name="EndsWith string matcher">
       <Expression success="false" type="CHECK_THAT" filename="projects/SelfTest/MiscTests.cpp" >
         <Original>
-          testStringForMatching() EndsWith( &quot;this&quot; )
+          testStringForMatching() EndsWith( "this" )
         </Original>
         <Expanded>
-          &quot;this string contains 'abc' as a substring&quot; ends with: &quot;this&quot;
+          "this string contains 'abc' as a substring" ends with: "this"
         </Expanded>
       </Expression>
       <OverallResult success="false"/>
@@ -3502,10 +3502,10 @@
     <TestCase name="Equals string matcher">
       <Expression success="false" type="CHECK_THAT" filename="projects/SelfTest/MiscTests.cpp" >
         <Original>
-          testStringForMatching() Equals( &quot;something else&quot; )
+          testStringForMatching() Equals( "something else" )
         </Original>
         <Expanded>
-          &quot;this string contains 'abc' as a substring&quot; equals: &quot;something else&quot;
+          "this string contains 'abc' as a substring" equals: "something else"
         </Expanded>
       </Expression>
       <OverallResult success="false"/>
@@ -3513,10 +3513,10 @@
     <TestCase name="Equals string matcher, with NULL">
       <Expression success="true" type="REQUIRE_THAT" filename="projects/SelfTest/MiscTests.cpp" >
         <Original>
-          &quot;&quot; Equals(nullptr)
+          "" Equals(nullptr)
         </Original>
         <Expanded>
-          &quot;&quot; equals: &quot;&quot;
+          "" equals: ""
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -3524,10 +3524,10 @@
     <TestCase name="AllOf matcher">
       <Expression success="true" type="CHECK_THAT" filename="projects/SelfTest/MiscTests.cpp" >
         <Original>
-          testStringForMatching() AllOf( Catch::Contains( &quot;string&quot; ), Catch::Contains( &quot;abc&quot; ) )
+          testStringForMatching() AllOf( Catch::Contains( "string" ), Catch::Contains( "abc" ) )
         </Original>
         <Expanded>
-          &quot;this string contains 'abc' as a substring&quot; ( contains: &quot;string&quot; and contains: &quot;abc&quot; )
+          "this string contains 'abc' as a substring" ( contains: "string" and contains: "abc" )
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -3535,18 +3535,18 @@
     <TestCase name="AnyOf matcher">
       <Expression success="true" type="CHECK_THAT" filename="projects/SelfTest/MiscTests.cpp" >
         <Original>
-          testStringForMatching() AnyOf( Catch::Contains( &quot;string&quot; ), Catch::Contains( &quot;not there&quot; ) )
+          testStringForMatching() AnyOf( Catch::Contains( "string" ), Catch::Contains( "not there" ) )
         </Original>
         <Expanded>
-          &quot;this string contains 'abc' as a substring&quot; ( contains: &quot;string&quot; or contains: &quot;not there&quot; )
+          "this string contains 'abc' as a substring" ( contains: "string" or contains: "not there" )
         </Expanded>
       </Expression>
       <Expression success="true" type="CHECK_THAT" filename="projects/SelfTest/MiscTests.cpp" >
         <Original>
-          testStringForMatching() AnyOf( Catch::Contains( &quot;not there&quot; ), Catch::Contains( &quot;string&quot; ) )
+          testStringForMatching() AnyOf( Catch::Contains( "not there" ), Catch::Contains( "string" ) )
         </Original>
         <Expanded>
-          &quot;this string contains 'abc' as a substring&quot; ( contains: &quot;not there&quot; or contains: &quot;string&quot; )
+          "this string contains 'abc' as a substring" ( contains: "not there" or contains: "string" )
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -3554,10 +3554,10 @@
     <TestCase name="Equals">
       <Expression success="true" type="CHECK_THAT" filename="projects/SelfTest/MiscTests.cpp" >
         <Original>
-          testStringForMatching() Equals( &quot;this string contains 'abc' as a substring&quot; )
+          testStringForMatching() Equals( "this string contains 'abc' as a substring" )
         </Original>
         <Expanded>
-          &quot;this string contains 'abc' as a substring&quot; equals: &quot;this string contains 'abc' as a substring&quot;
+          "this string contains 'abc' as a substring" equals: "this string contains 'abc' as a substring"
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -3795,14 +3795,14 @@
           s1 == s2
         </Original>
         <Expanded>
-          &quot;if ($b == 10) {
+          "if ($b == 10) {
 		$a	= 20;
-}&quot;
+}"
 ==
-&quot;if ($b == 10) {
+"if ($b == 10) {
 	$a = 20;
 }
-&quot;
+"
         </Expanded>
       </Expression>
       <OverallResult success="false"/>
@@ -3810,10 +3810,10 @@
     <TestCase name="toString on const wchar_t const pointer returns the string contents">
       <Expression success="true" type="CHECK" filename="projects/SelfTest/MiscTests.cpp" >
         <Original>
-          result == &quot;\&quot;wide load\&quot;&quot;
+          result == "\"wide load\""
         </Original>
         <Expanded>
-          &quot;&quot;wide load&quot;&quot; == &quot;&quot;wide load&quot;&quot;
+          ""wide load"" == ""wide load""
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -3821,10 +3821,10 @@
     <TestCase name="toString on const wchar_t pointer returns the string contents">
       <Expression success="true" type="CHECK" filename="projects/SelfTest/MiscTests.cpp" >
         <Original>
-          result == &quot;\&quot;wide load\&quot;&quot;
+          result == "\"wide load\""
         </Original>
         <Expanded>
-          &quot;&quot;wide load&quot;&quot; == &quot;&quot;wide load&quot;&quot;
+          ""wide load"" == ""wide load""
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -3832,10 +3832,10 @@
     <TestCase name="toString on wchar_t const pointer returns the string contents">
       <Expression success="true" type="CHECK" filename="projects/SelfTest/MiscTests.cpp" >
         <Original>
-          result == &quot;\&quot;wide load\&quot;&quot;
+          result == "\"wide load\""
         </Original>
         <Expanded>
-          &quot;&quot;wide load&quot;&quot; == &quot;&quot;wide load&quot;&quot;
+          ""wide load"" == ""wide load""
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -3843,12 +3843,125 @@
     <TestCase name="toString on wchar_t returns the string contents">
       <Expression success="true" type="CHECK" filename="projects/SelfTest/MiscTests.cpp" >
         <Original>
-          result == &quot;\&quot;wide load\&quot;&quot;
+          result == "\"wide load\""
         </Original>
         <Expanded>
-          &quot;&quot;wide load&quot;&quot; == &quot;&quot;wide load&quot;&quot;
+          ""wide load"" == ""wide load""
         </Expanded>
       </Expression>
+      <OverallResult success="true"/>
+    </TestCase>
+    <TestCase name="XmlEncode">
+      <Section name="normal string">
+        <Expression success="true" type="REQUIRE" filename="projects/SelfTest/MiscTests.cpp" >
+          <Original>
+            encode( "normal string" ) == "normal string"
+          </Original>
+          <Expanded>
+            "normal string" == "normal string"
+          </Expanded>
+        </Expression>
+        <OverallResults successes="1" failures="0" expectedFailures="0"/>
+      </Section>
+      <Section name="empty string">
+        <Expression success="true" type="REQUIRE" filename="projects/SelfTest/MiscTests.cpp" >
+          <Original>
+            encode( "" ) == ""
+          </Original>
+          <Expanded>
+            "" == ""
+          </Expanded>
+        </Expression>
+        <OverallResults successes="1" failures="0" expectedFailures="0"/>
+      </Section>
+      <Section name="string with ampersand">
+        <Expression success="true" type="REQUIRE" filename="projects/SelfTest/MiscTests.cpp" >
+          <Original>
+            encode( "smith &amp; jones" ) == "smith &amp;amp; jones"
+          </Original>
+          <Expanded>
+            "smith &amp;amp; jones" == "smith &amp;amp; jones"
+          </Expanded>
+        </Expression>
+        <OverallResults successes="1" failures="0" expectedFailures="0"/>
+      </Section>
+      <Section name="string with less-than">
+        <Expression success="true" type="REQUIRE" filename="projects/SelfTest/MiscTests.cpp" >
+          <Original>
+            encode( "smith &lt; jones" ) == "smith &amp;lt; jones"
+          </Original>
+          <Expanded>
+            "smith &amp;lt; jones" == "smith &amp;lt; jones"
+          </Expanded>
+        </Expression>
+        <OverallResults successes="1" failures="0" expectedFailures="0"/>
+      </Section>
+      <Section name="string with greater-than">
+        <Expression success="true" type="REQUIRE" filename="projects/SelfTest/MiscTests.cpp" >
+          <Original>
+            encode( "smith > jones" ) == "smith > jones"
+          </Original>
+          <Expanded>
+            "smith > jones" == "smith > jones"
+          </Expanded>
+        </Expression>
+        <Expression success="true" type="REQUIRE" filename="projects/SelfTest/MiscTests.cpp" >
+          <Original>
+            encode( "smith ]]&gt; jones" ) == "smith ]]&amp;gt; jones"
+          </Original>
+          <Expanded>
+            "smith ]]&amp;gt; jones"
+==
+"smith ]]&amp;gt; jones"
+          </Expanded>
+        </Expression>
+        <OverallResults successes="2" failures="0" expectedFailures="0"/>
+      </Section>
+      <Section name="string with quotes">
+        <Expression success="true" type="REQUIRE" filename="projects/SelfTest/MiscTests.cpp" >
+          <Original>
+            encode( stringWithQuotes ) == stringWithQuotes
+          </Original>
+          <Expanded>
+            "don't "quote" me on that"
+==
+"don't "quote" me on that"
+          </Expanded>
+        </Expression>
+        <Expression success="true" type="REQUIRE" filename="projects/SelfTest/MiscTests.cpp" >
+          <Original>
+            encode( stringWithQuotes, Catch::XmlEncode::ForAttributes ) == "don't &amp;quot;quote&amp;quot; me on that"
+          </Original>
+          <Expanded>
+            "don't &amp;quot;quote&amp;quot; me on that"
+==
+"don't &amp;quot;quote&amp;quot; me on that"
+          </Expanded>
+        </Expression>
+        <OverallResults successes="2" failures="0" expectedFailures="0"/>
+      </Section>
+      <Section name="string with control char (1)">
+        <Expression success="true" type="REQUIRE" filename="projects/SelfTest/MiscTests.cpp" >
+          <Original>
+            encode( "[\x01]" ) == "[&amp;#x1]"
+          </Original>
+          <Expanded>
+            "[&amp;#x1]" == "[&amp;#x1]"
+          </Expanded>
+        </Expression>
+        <OverallResults successes="1" failures="0" expectedFailures="0"/>
+      </Section>
+      <Section name="string with control char (x7F)">
+        <Expression success="true" type="REQUIRE" filename="projects/SelfTest/MiscTests.cpp" >
+          <Original>
+            encode( "[\x7F]" ) == "[&amp;#x7F]"
+          </Original>
+          <Expanded>
+            "[&amp;#x7F]" == "[&amp;#x7F]"
+          </Expanded>
+        </Expression>
+        <OverallResults successes="1" failures="0" expectedFailures="0"/>
+      </Section>
       <OverallResult success="true"/>
     </TestCase>
     <TestCase name="Process can be configured on command line">
@@ -3907,7 +4020,7 @@
           </Expression>
           <Expression success="true" type="REQUIRE" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              cfg.testSpec().matches( fakeTestCase( &quot;notIncluded&quot; ) ) == false
+              cfg.testSpec().matches( fakeTestCase( "notIncluded" ) ) == false
             </Original>
             <Expanded>
               false == false
@@ -3915,7 +4028,7 @@
           </Expression>
           <Expression success="true" type="REQUIRE" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              cfg.testSpec().matches( fakeTestCase( &quot;test1&quot; ) )
+              cfg.testSpec().matches( fakeTestCase( "test1" ) )
             </Original>
             <Expanded>
               true
@@ -3937,7 +4050,7 @@
           </Expression>
           <Expression success="true" type="REQUIRE" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              cfg.testSpec().matches( fakeTestCase( &quot;test1&quot; ) ) == false
+              cfg.testSpec().matches( fakeTestCase( "test1" ) ) == false
             </Original>
             <Expanded>
               false == false
@@ -3945,7 +4058,7 @@
           </Expression>
           <Expression success="true" type="REQUIRE" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              cfg.testSpec().matches( fakeTestCase( &quot;alwaysIncluded&quot; ) )
+              cfg.testSpec().matches( fakeTestCase( "alwaysIncluded" ) )
             </Original>
             <Expanded>
               true
@@ -3967,7 +4080,7 @@
           </Expression>
           <Expression success="true" type="REQUIRE" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              cfg.testSpec().matches( fakeTestCase( &quot;test1&quot; ) ) == false
+              cfg.testSpec().matches( fakeTestCase( "test1" ) ) == false
             </Original>
             <Expanded>
               false == false
@@ -3975,7 +4088,7 @@
           </Expression>
           <Expression success="true" type="REQUIRE" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              cfg.testSpec().matches( fakeTestCase( &quot;alwaysIncluded&quot; ) )
+              cfg.testSpec().matches( fakeTestCase( "alwaysIncluded" ) )
             </Original>
             <Expanded>
               true
@@ -3997,10 +4110,10 @@
           </Expression>
           <Expression success="true" type="REQUIRE" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              config.reporterName == &quot;console&quot;
+              config.reporterName == "console"
             </Original>
             <Expanded>
-              &quot;console&quot; == &quot;console&quot;
+              "console" == "console"
             </Expanded>
           </Expression>
           <OverallResults successes="2" failures="0" expectedFailures="0"/>
@@ -4019,10 +4132,10 @@
           </Expression>
           <Expression success="true" type="REQUIRE" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              config.reporterName == &quot;xml&quot;
+              config.reporterName == "xml"
             </Original>
             <Expanded>
-              &quot;xml&quot; == &quot;xml&quot;
+              "xml" == "xml"
             </Expanded>
           </Expression>
           <OverallResults successes="2" failures="0" expectedFailures="0"/>
@@ -4041,10 +4154,10 @@
           </Expression>
           <Expression success="true" type="REQUIRE" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              config.reporterName == &quot;junit&quot;
+              config.reporterName == "junit"
             </Original>
             <Expanded>
-              &quot;junit&quot; == &quot;junit&quot;
+              "junit" == "junit"
             </Expanded>
           </Expression>
           <OverallResults successes="2" failures="0" expectedFailures="0"/>
@@ -4143,11 +4256,11 @@
         <Section name="-x must be greater than zero">
           <Expression success="true" type="REQUIRE_THAT" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              parseIntoConfigAndReturnError( argv, config ) Contains( &quot;greater than zero&quot; )
+              parseIntoConfigAndReturnError( argv, config ) Contains( "greater than zero" )
             </Original>
             <Expanded>
-              &quot;Value after -x or --abortAfter must be greater than zero
-- while parsing: (-x, --abortx &lt;no. failures>)&quot; contains: &quot;greater than zero&quot;
+              "Value after -x or --abortAfter must be greater than zero
+- while parsing: (-x, --abortx &lt;no. failures>)" contains: "greater than zero"
             </Expanded>
           </Expression>
           <OverallResults successes="1" failures="0" expectedFailures="0"/>
@@ -4158,11 +4271,11 @@
         <Section name="-x must be numeric">
           <Expression success="true" type="REQUIRE_THAT" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              parseIntoConfigAndReturnError( argv, config ) Contains( &quot;-x&quot; )
+              parseIntoConfigAndReturnError( argv, config ) Contains( "-x" )
             </Original>
             <Expanded>
-              &quot;Unable to convert oops to destination type
-- while parsing: (-x, --abortx &lt;no. failures>)&quot; contains: &quot;-x&quot;
+              "Unable to convert oops to destination type
+- while parsing: (-x, --abortx &lt;no. failures>)" contains: "-x"
             </Expanded>
           </Expression>
           <OverallResults successes="1" failures="0" expectedFailures="0"/>
@@ -4225,10 +4338,10 @@
           </Expression>
           <Expression success="true" type="REQUIRE" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              config.outputFilename == &quot;filename.ext&quot;
+              config.outputFilename == "filename.ext"
             </Original>
             <Expanded>
-              &quot;filename.ext&quot; == &quot;filename.ext&quot;
+              "filename.ext" == "filename.ext"
             </Expanded>
           </Expression>
           <OverallResults successes="2" failures="0" expectedFailures="0"/>
@@ -4247,10 +4360,10 @@
           </Expression>
           <Expression success="true" type="REQUIRE" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              config.outputFilename == &quot;filename.ext&quot;
+              config.outputFilename == "filename.ext"
             </Original>
             <Expanded>
-              &quot;filename.ext&quot; == &quot;filename.ext&quot;
+              "filename.ext" == "filename.ext"
             </Expanded>
           </Expression>
           <OverallResults successes="2" failures="0" expectedFailures="0"/>
@@ -4349,9 +4462,9 @@
               Text( testString, TextAttributes().setWidth( 80 ) ).toString() == testString
             </Original>
             <Expanded>
-              &quot;one two three four&quot;
+              "one two three four"
 ==
-&quot;one two three four&quot;
+"one two three four"
             </Expanded>
           </Expression>
           <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
@@ -4359,9 +4472,9 @@
               Text( testString, TextAttributes().setWidth( 18 ) ).toString() == testString
             </Original>
             <Expanded>
-              &quot;one two three four&quot;
+              "one two three four"
 ==
-&quot;one two three four&quot;
+"one two three four"
             </Expanded>
           </Expression>
           <OverallResults successes="2" failures="0" expectedFailures="0"/>
@@ -4372,62 +4485,62 @@
         <Section name="Wrapped once">
           <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              Text( testString, TextAttributes().setWidth( 17 ) ).toString() == &quot;one two three\nfour&quot;
+              Text( testString, TextAttributes().setWidth( 17 ) ).toString() == "one two three\nfour"
             </Original>
             <Expanded>
-              &quot;one two three
-four&quot;
+              "one two three
+four"
 ==
-&quot;one two three
-four&quot;
+"one two three
+four"
             </Expanded>
           </Expression>
           <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              Text( testString, TextAttributes().setWidth( 16 ) ).toString() == &quot;one two three\nfour&quot;
+              Text( testString, TextAttributes().setWidth( 16 ) ).toString() == "one two three\nfour"
             </Original>
             <Expanded>
-              &quot;one two three
-four&quot;
+              "one two three
+four"
 ==
-&quot;one two three
-four&quot;
+"one two three
+four"
             </Expanded>
           </Expression>
           <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              Text( testString, TextAttributes().setWidth( 14 ) ).toString() == &quot;one two three\nfour&quot;
+              Text( testString, TextAttributes().setWidth( 14 ) ).toString() == "one two three\nfour"
             </Original>
             <Expanded>
-              &quot;one two three
-four&quot;
+              "one two three
+four"
 ==
-&quot;one two three
-four&quot;
+"one two three
+four"
             </Expanded>
           </Expression>
           <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              Text( testString, TextAttributes().setWidth( 13 ) ).toString() == &quot;one two three\nfour&quot;
+              Text( testString, TextAttributes().setWidth( 13 ) ).toString() == "one two three\nfour"
             </Original>
             <Expanded>
-              &quot;one two three
-four&quot;
+              "one two three
+four"
 ==
-&quot;one two three
-four&quot;
+"one two three
+four"
             </Expanded>
           </Expression>
           <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              Text( testString, TextAttributes().setWidth( 12 ) ).toString() == &quot;one two\nthree four&quot;
+              Text( testString, TextAttributes().setWidth( 12 ) ).toString() == "one two\nthree four"
             </Original>
             <Expanded>
-              &quot;one two
-three four&quot;
+              "one two
+three four"
 ==
-&quot;one two
-three four&quot;
+"one two
+three four"
             </Expanded>
           </Expression>
           <OverallResults successes="5" failures="0" expectedFailures="0"/>
@@ -4438,44 +4551,44 @@ three four&quot;
         <Section name="Wrapped twice">
           <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              Text( testString, TextAttributes().setWidth( 9 ) ).toString() == &quot;one two\nthree\nfour&quot;
+              Text( testString, TextAttributes().setWidth( 9 ) ).toString() == "one two\nthree\nfour"
             </Original>
             <Expanded>
-              &quot;one two
+              "one two
 three
-four&quot;
+four"
 ==
-&quot;one two
+"one two
 three
-four&quot;
+four"
             </Expanded>
           </Expression>
           <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              Text( testString, TextAttributes().setWidth( 8 ) ).toString() == &quot;one two\nthree\nfour&quot;
+              Text( testString, TextAttributes().setWidth( 8 ) ).toString() == "one two\nthree\nfour"
             </Original>
             <Expanded>
-              &quot;one two
+              "one two
 three
-four&quot;
+four"
 ==
-&quot;one two
+"one two
 three
-four&quot;
+four"
             </Expanded>
           </Expression>
           <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              Text( testString, TextAttributes().setWidth( 7 ) ).toString() == &quot;one two\nthree\nfour&quot;
+              Text( testString, TextAttributes().setWidth( 7 ) ).toString() == "one two\nthree\nfour"
             </Original>
             <Expanded>
-              &quot;one two
+              "one two
 three
-four&quot;
+four"
 ==
-&quot;one two
+"one two
 three
-four&quot;
+four"
             </Expanded>
           </Expression>
           <OverallResults successes="3" failures="0" expectedFailures="0"/>
@@ -4486,34 +4599,34 @@ four&quot;
         <Section name="Wrapped three times">
           <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              Text( testString, TextAttributes().setWidth( 6 ) ).toString() == &quot;one\ntwo\nthree\nfour&quot;
+              Text( testString, TextAttributes().setWidth( 6 ) ).toString() == "one\ntwo\nthree\nfour"
             </Original>
             <Expanded>
-              &quot;one
+              "one
 two
 three
-four&quot;
+four"
 ==
-&quot;one
+"one
 two
 three
-four&quot;
+four"
             </Expanded>
           </Expression>
           <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              Text( testString, TextAttributes().setWidth( 5 ) ).toString() == &quot;one\ntwo\nthree\nfour&quot;
+              Text( testString, TextAttributes().setWidth( 5 ) ).toString() == "one\ntwo\nthree\nfour"
             </Original>
             <Expanded>
-              &quot;one
+              "one
 two
 three
-four&quot;
+four"
 ==
-&quot;one
+"one
 two
 three
-four&quot;
+four"
             </Expanded>
           </Expression>
           <OverallResults successes="2" failures="0" expectedFailures="0"/>
@@ -4524,78 +4637,78 @@ four&quot;
         <Section name="Short wrap">
           <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              Text( &quot;abcdef&quot;, TextAttributes().setWidth( 4 ) ).toString() == &quot;abc-\ndef&quot;
+              Text( "abcdef", TextAttributes().setWidth( 4 ) ).toString() == "abc-\ndef"
             </Original>
             <Expanded>
-              &quot;abc-
-def&quot;
+              "abc-
+def"
 ==
-&quot;abc-
-def&quot;
+"abc-
+def"
             </Expanded>
           </Expression>
           <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              Text( &quot;abcdefg&quot;, TextAttributes().setWidth( 4 ) ).toString() == &quot;abc-\ndefg&quot;
+              Text( "abcdefg", TextAttributes().setWidth( 4 ) ).toString() == "abc-\ndefg"
             </Original>
             <Expanded>
-              &quot;abc-
-defg&quot;
+              "abc-
+defg"
 ==
-&quot;abc-
-defg&quot;
+"abc-
+defg"
             </Expanded>
           </Expression>
           <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              Text( &quot;abcdefgh&quot;, TextAttributes().setWidth( 4 ) ).toString() == &quot;abc-\ndef-\ngh&quot;
+              Text( "abcdefgh", TextAttributes().setWidth( 4 ) ).toString() == "abc-\ndef-\ngh"
             </Original>
             <Expanded>
-              &quot;abc-
+              "abc-
 def-
-gh&quot;
+gh"
 ==
-&quot;abc-
+"abc-
 def-
-gh&quot;
+gh"
             </Expanded>
           </Expression>
           <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              Text( testString, TextAttributes().setWidth( 4 ) ).toString() == &quot;one\ntwo\nthr-\nee\nfour&quot;
+              Text( testString, TextAttributes().setWidth( 4 ) ).toString() == "one\ntwo\nthr-\nee\nfour"
             </Original>
             <Expanded>
-              &quot;one
+              "one
 two
 thr-
 ee
-four&quot;
+four"
 ==
-&quot;one
+"one
 two
 thr-
 ee
-four&quot;
+four"
             </Expanded>
           </Expression>
           <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              Text( testString, TextAttributes().setWidth( 3 ) ).toString() == &quot;one\ntwo\nth-\nree\nfo-\nur&quot;
+              Text( testString, TextAttributes().setWidth( 3 ) ).toString() == "one\ntwo\nth-\nree\nfo-\nur"
             </Original>
             <Expanded>
-              &quot;one
+              "one
 two
 th-
 ree
 fo-
-ur&quot;
+ur"
 ==
-&quot;one
+"one
 two
 th-
 ree
 fo-
-ur&quot;
+ur"
             </Expanded>
           </Expression>
           <OverallResults successes="5" failures="0" expectedFailures="0"/>
@@ -4614,34 +4727,34 @@ ur&quot;
           </Expression>
           <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              text[0] == &quot;one&quot;
+              text[0] == "one"
             </Original>
             <Expanded>
-              &quot;one&quot; == &quot;one&quot;
+              "one" == "one"
             </Expanded>
           </Expression>
           <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              text[1] == &quot;two&quot;
+              text[1] == "two"
             </Original>
             <Expanded>
-              &quot;two&quot; == &quot;two&quot;
+              "two" == "two"
             </Expanded>
           </Expression>
           <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              text[2] == &quot;three&quot;
+              text[2] == "three"
             </Original>
             <Expanded>
-              &quot;three&quot; == &quot;three&quot;
+              "three" == "three"
             </Expanded>
           </Expression>
           <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              text[3] == &quot;four&quot;
+              text[3] == "four"
             </Original>
             <Expanded>
-              &quot;four&quot; == &quot;four&quot;
+              "four" == "four"
             </Expanded>
           </Expression>
           <OverallResults successes="5" failures="0" expectedFailures="0"/>
@@ -4652,16 +4765,16 @@ ur&quot;
         <Section name="Indent first line differently">
           <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              text.toString() == &quot; one two\n    three\n    four&quot;
+              text.toString() == " one two\n    three\n    four"
             </Original>
             <Expanded>
-              &quot; one two
+              " one two
     three
-    four&quot;
+    four"
 ==
-&quot; one two
+" one two
     three
-    four&quot;
+    four"
             </Expanded>
           </Expression>
           <OverallResults successes="1" failures="0" expectedFailures="0"/>
@@ -4675,11 +4788,11 @@ ur&quot;
               Text( testString, TextAttributes().setWidth( 80 ) ).toString() == testString
             </Original>
             <Expanded>
-              &quot;one two
-three four&quot;
+              "one two
+three four"
 ==
-&quot;one two
-three four&quot;
+"one two
+three four"
             </Expanded>
           </Expression>
           <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
@@ -4687,11 +4800,11 @@ three four&quot;
               Text( testString, TextAttributes().setWidth( 18 ) ).toString() == testString
             </Original>
             <Expanded>
-              &quot;one two
-three four&quot;
+              "one two
+three four"
 ==
-&quot;one two
-three four&quot;
+"one two
+three four"
             </Expanded>
           </Expression>
           <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
@@ -4699,11 +4812,11 @@ three four&quot;
               Text( testString, TextAttributes().setWidth( 10 ) ).toString() == testString
             </Original>
             <Expanded>
-              &quot;one two
-three four&quot;
+              "one two
+three four"
 ==
-&quot;one two
-three four&quot;
+"one two
+three four"
             </Expanded>
           </Expression>
           <OverallResults successes="3" failures="0" expectedFailures="0"/>
@@ -4714,34 +4827,34 @@ three four&quot;
         <Section name="Trailing newline">
           <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              Text( &quot;abcdef\n&quot;, TextAttributes().setWidth( 10 ) ).toString() == &quot;abcdef\n&quot;
+              Text( "abcdef\n", TextAttributes().setWidth( 10 ) ).toString() == "abcdef\n"
             </Original>
             <Expanded>
-              &quot;abcdef
-&quot;
+              "abcdef
+"
 ==
-&quot;abcdef
-&quot;
+"abcdef
+"
             </Expanded>
           </Expression>
           <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              Text( &quot;abcdef&quot;, TextAttributes().setWidth( 6 ) ).toString() == &quot;abcdef&quot;
+              Text( "abcdef", TextAttributes().setWidth( 6 ) ).toString() == "abcdef"
             </Original>
             <Expanded>
-              &quot;abcdef&quot; == &quot;abcdef&quot;
+              "abcdef" == "abcdef"
             </Expanded>
           </Expression>
           <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              Text( &quot;abcdef\n&quot;, TextAttributes().setWidth( 6 ) ).toString() == &quot;abcdef\n&quot;
+              Text( "abcdef\n", TextAttributes().setWidth( 6 ) ).toString() == "abcdef\n"
             </Original>
             <Expanded>
-              &quot;abcdef
-&quot;
+              "abcdef
+"
 ==
-&quot;abcdef
-&quot;
+"abcdef
+"
             </Expanded>
           </Expression>
           <OverallResults successes="3" failures="0" expectedFailures="0"/>
@@ -4752,44 +4865,44 @@ three four&quot;
         <Section name="Wrapped once">
           <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              Text( testString, TextAttributes().setWidth( 9 ) ).toString() == &quot;one two\nthree\nfour&quot;
+              Text( testString, TextAttributes().setWidth( 9 ) ).toString() == "one two\nthree\nfour"
             </Original>
             <Expanded>
-              &quot;one two
+              "one two
 three
-four&quot;
+four"
 ==
-&quot;one two
+"one two
 three
-four&quot;
+four"
             </Expanded>
           </Expression>
           <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              Text( testString, TextAttributes().setWidth( 8 ) ).toString() == &quot;one two\nthree\nfour&quot;
+              Text( testString, TextAttributes().setWidth( 8 ) ).toString() == "one two\nthree\nfour"
             </Original>
             <Expanded>
-              &quot;one two
+              "one two
 three
-four&quot;
+four"
 ==
-&quot;one two
+"one two
 three
-four&quot;
+four"
             </Expanded>
           </Expression>
           <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              Text( testString, TextAttributes().setWidth( 7 ) ).toString() == &quot;one two\nthree\nfour&quot;
+              Text( testString, TextAttributes().setWidth( 7 ) ).toString() == "one two\nthree\nfour"
             </Original>
             <Expanded>
-              &quot;one two
+              "one two
 three
-four&quot;
+four"
 ==
-&quot;one two
+"one two
 three
-four&quot;
+four"
             </Expanded>
           </Expression>
           <OverallResults successes="3" failures="0" expectedFailures="0"/>
@@ -4800,18 +4913,18 @@ four&quot;
         <Section name="Wrapped twice">
           <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
             <Original>
-              Text( testString, TextAttributes().setWidth( 6 ) ).toString() == &quot;one\ntwo\nthree\nfour&quot;
+              Text( testString, TextAttributes().setWidth( 6 ) ).toString() == "one\ntwo\nthree\nfour"
             </Original>
             <Expanded>
-              &quot;one
+              "one
 two
 three
-four&quot;
+four"
 ==
-&quot;one
+"one
 two
 three
-four&quot;
+four"
             </Expanded>
           </Expression>
           <OverallResults successes="1" failures="0" expectedFailures="0"/>
@@ -4821,18 +4934,18 @@ four&quot;
       <Section name="With tabs">
         <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
           <Original>
-            Text( testString, TextAttributes().setWidth( 15 ) ).toString() == &quot;one two three\n        four\n        five\n        six&quot;
+            Text( testString, TextAttributes().setWidth( 15 ) ).toString() == "one two three\n        four\n        five\n        six"
           </Original>
           <Expanded>
-            &quot;one two three
+            "one two three
         four
         five
-        six&quot;
+        six"
 ==
-&quot;one two three
+"one two three
         four
         five
-        six&quot;
+        six"
           </Expanded>
         </Expression>
         <OverallResults successes="1" failures="0" expectedFailures="0"/>
@@ -4843,7 +4956,7 @@ four&quot;
       <Section name="replace single char">
         <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
           <Original>
-            replaceInPlace( letters, &quot;b&quot;, &quot;z&quot; )
+            replaceInPlace( letters, "b", "z" )
           </Original>
           <Expanded>
             true
@@ -4851,10 +4964,10 @@ four&quot;
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
           <Original>
-            letters == &quot;azcdefcg&quot;
+            letters == "azcdefcg"
           </Original>
           <Expanded>
-            &quot;azcdefcg&quot; == &quot;azcdefcg&quot;
+            "azcdefcg" == "azcdefcg"
           </Expanded>
         </Expression>
         <OverallResults successes="2" failures="0" expectedFailures="0"/>
@@ -4862,7 +4975,7 @@ four&quot;
       <Section name="replace two chars">
         <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
           <Original>
-            replaceInPlace( letters, &quot;c&quot;, &quot;z&quot; )
+            replaceInPlace( letters, "c", "z" )
           </Original>
           <Expanded>
             true
@@ -4870,10 +4983,10 @@ four&quot;
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
           <Original>
-            letters == &quot;abzdefzg&quot;
+            letters == "abzdefzg"
           </Original>
           <Expanded>
-            &quot;abzdefzg&quot; == &quot;abzdefzg&quot;
+            "abzdefzg" == "abzdefzg"
           </Expanded>
         </Expression>
         <OverallResults successes="2" failures="0" expectedFailures="0"/>
@@ -4881,7 +4994,7 @@ four&quot;
       <Section name="replace first char">
         <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
           <Original>
-            replaceInPlace( letters, &quot;a&quot;, &quot;z&quot; )
+            replaceInPlace( letters, "a", "z" )
           </Original>
           <Expanded>
             true
@@ -4889,10 +5002,10 @@ four&quot;
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
           <Original>
-            letters == &quot;zbcdefcg&quot;
+            letters == "zbcdefcg"
           </Original>
           <Expanded>
-            &quot;zbcdefcg&quot; == &quot;zbcdefcg&quot;
+            "zbcdefcg" == "zbcdefcg"
           </Expanded>
         </Expression>
         <OverallResults successes="2" failures="0" expectedFailures="0"/>
@@ -4900,7 +5013,7 @@ four&quot;
       <Section name="replace last char">
         <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
           <Original>
-            replaceInPlace( letters, &quot;g&quot;, &quot;z&quot; )
+            replaceInPlace( letters, "g", "z" )
           </Original>
           <Expanded>
             true
@@ -4908,10 +5021,10 @@ four&quot;
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
           <Original>
-            letters == &quot;abcdefcz&quot;
+            letters == "abcdefcz"
           </Original>
           <Expanded>
-            &quot;abcdefcz&quot; == &quot;abcdefcz&quot;
+            "abcdefcz" == "abcdefcz"
           </Expanded>
         </Expression>
         <OverallResults successes="2" failures="0" expectedFailures="0"/>
@@ -4919,7 +5032,7 @@ four&quot;
       <Section name="replace all chars">
         <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
           <Original>
-            replaceInPlace( letters, letters, &quot;replaced&quot; )
+            replaceInPlace( letters, letters, "replaced" )
           </Original>
           <Expanded>
             true
@@ -4927,10 +5040,10 @@ four&quot;
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
           <Original>
-            letters == &quot;replaced&quot;
+            letters == "replaced"
           </Original>
           <Expanded>
-            &quot;replaced&quot; == &quot;replaced&quot;
+            "replaced" == "replaced"
           </Expanded>
         </Expression>
         <OverallResults successes="2" failures="0" expectedFailures="0"/>
@@ -4938,7 +5051,7 @@ four&quot;
       <Section name="replace no chars">
         <Expression success="true" type="CHECK_FALSE" filename="projects/SelfTest/TestMain.cpp" >
           <Original>
-            !replaceInPlace( letters, &quot;x&quot;, &quot;z&quot; )
+            !replaceInPlace( letters, "x", "z" )
           </Original>
           <Expanded>
             !false
@@ -4949,7 +5062,7 @@ four&quot;
             letters == letters
           </Original>
           <Expanded>
-            &quot;abcdefcg&quot; == &quot;abcdefcg&quot;
+            "abcdefcg" == "abcdefcg"
           </Expanded>
         </Expression>
         <OverallResults successes="2" failures="0" expectedFailures="0"/>
@@ -4957,7 +5070,7 @@ four&quot;
       <Section name="escape '">
         <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
           <Original>
-            replaceInPlace( s, &quot;'&quot;, &quot;|'&quot; )
+            replaceInPlace( s, "'", "|'" )
           </Original>
           <Expanded>
             true
@@ -4965,10 +5078,10 @@ four&quot;
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
           <Original>
-            s == &quot;didn|'t&quot;
+            s == "didn|'t"
           </Original>
           <Expanded>
-            &quot;didn|'t&quot; == &quot;didn|'t&quot;
+            "didn|'t" == "didn|'t"
           </Expanded>
         </Expression>
         <OverallResults successes="2" failures="0" expectedFailures="0"/>
@@ -4981,22 +5094,22 @@ four&quot;
     <TestCase name="Text can be formatted using the Text class">
       <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
         <Original>
-          Text( &quot;hi there&quot; ).toString() == &quot;hi there&quot;
+          Text( "hi there" ).toString() == "hi there"
         </Original>
         <Expanded>
-          &quot;hi there&quot; == &quot;hi there&quot;
+          "hi there" == "hi there"
         </Expanded>
       </Expression>
       <Expression success="true" type="CHECK" filename="projects/SelfTest/TestMain.cpp" >
         <Original>
-          Text( &quot;hi there&quot;, narrow ).toString() == &quot;hi\nthere&quot;
+          Text( "hi there", narrow ).toString() == "hi\nthere"
         </Original>
         <Expanded>
-          &quot;hi
-there&quot;
+          "hi
+there"
 ==
-&quot;hi
-there&quot;
+"hi
+there"
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -5004,10 +5117,10 @@ there&quot;
     <TestCase name="Long text is truncted">
       <Expression success="true" type="CHECK_THAT" filename="projects/SelfTest/TestMain.cpp" >
         <Original>
-          t.toString() EndsWith( &quot;... message truncated due to excessive size&quot; )
+          t.toString() EndsWith( "... message truncated due to excessive size" )
         </Original>
         <Expanded>
-          &quot;******************************************************************************-
+          "******************************************************************************-
 ******************************************************************************-
 ************************
 ******************************************************************************-
@@ -6007,7 +6120,7 @@ there&quot;
 ******************************************************************************-
 ************************
 ******************************************************************************-
-... message truncated due to excessive size&quot; ends with: &quot;... message truncated due to excessive size&quot;
+... message truncated due to excessive size" ends with: "... message truncated due to excessive size"
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -6057,10 +6170,10 @@ there&quot;
     <TestCase name="string literals of different sizes can be compared">
       <Expression success="false" type="REQUIRE" filename="projects/SelfTest/TrickyTests.cpp" >
         <Original>
-          std::string( &quot;first&quot; ) == &quot;second&quot;
+          std::string( "first" ) == "second"
         </Original>
         <Expanded>
-          &quot;first&quot; == &quot;second&quot;
+          "first" == "second"
         </Expanded>
       </Expression>
       <OverallResult success="false"/>
@@ -6303,10 +6416,10 @@ there&quot;
     <TestCase name="non streamable - with conv. op">
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/TrickyTests.cpp" >
         <Original>
-          s == &quot;7&quot;
+          s == "7"
         </Original>
         <Expanded>
-          &quot;7&quot; == &quot;7&quot;
+          "7" == "7"
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -6380,12 +6493,12 @@ there&quot;
     <TestCase name="toString( has_toString )">
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ToStringWhich.cpp" >
         <Original>
-          Catch::toString( item ) == &quot;toString( has_toString )&quot;
+          Catch::toString( item ) == "toString( has_toString )"
         </Original>
         <Expanded>
-          &quot;toString( has_toString )&quot;
+          "toString( has_toString )"
 ==
-&quot;toString( has_toString )&quot;
+"toString( has_toString )"
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -6393,12 +6506,12 @@ there&quot;
     <TestCase name="toString( has_maker )">
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ToStringWhich.cpp" >
         <Original>
-          Catch::toString( item ) == &quot;StringMaker&lt;has_maker>&quot;
+          Catch::toString( item ) == "StringMaker&lt;has_maker>"
         </Original>
         <Expanded>
-          &quot;StringMaker&lt;has_maker>&quot;
+          "StringMaker&lt;has_maker>"
 ==
-&quot;StringMaker&lt;has_maker>&quot;
+"StringMaker&lt;has_maker>"
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -6406,12 +6519,12 @@ there&quot;
     <TestCase name="toString( has_maker_and_toString )">
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ToStringWhich.cpp" >
         <Original>
-          Catch::toString( item ) == &quot;toString( has_maker_and_toString )&quot;
+          Catch::toString( item ) == "toString( has_maker_and_toString )"
         </Original>
         <Expanded>
-          &quot;toString( has_maker_and_toString )&quot;
+          "toString( has_maker_and_toString )"
 ==
-&quot;toString( has_maker_and_toString )&quot;
+"toString( has_maker_and_toString )"
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -6419,10 +6532,10 @@ there&quot;
     <TestCase name="toString( vectors&lt;has_toString )">
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ToStringWhich.cpp" >
         <Original>
-          Catch::toString( v ) == &quot;{ {?} }&quot;
+          Catch::toString( v ) == "{ {?} }"
         </Original>
         <Expanded>
-          &quot;{ {?} }&quot; == &quot;{ {?} }&quot;
+          "{ {?} }" == "{ {?} }"
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -6430,12 +6543,12 @@ there&quot;
     <TestCase name="toString( vectors&lt;has_maker )">
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ToStringWhich.cpp" >
         <Original>
-          Catch::toString( v ) == &quot;{ StringMaker&lt;has_maker> }&quot;
+          Catch::toString( v ) == "{ StringMaker&lt;has_maker> }"
         </Original>
         <Expanded>
-          &quot;{ StringMaker&lt;has_maker> }&quot;
+          "{ StringMaker&lt;has_maker> }"
 ==
-&quot;{ StringMaker&lt;has_maker> }&quot;
+"{ StringMaker&lt;has_maker> }"
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -6443,12 +6556,12 @@ there&quot;
     <TestCase name="toString( vectors&lt;has_maker_and_toString )">
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ToStringWhich.cpp" >
         <Original>
-          Catch::toString( v ) == &quot;{ StringMaker&lt;has_maker_and_toString> }&quot;
+          Catch::toString( v ) == "{ StringMaker&lt;has_maker_and_toString> }"
         </Original>
         <Expanded>
-          &quot;{ StringMaker&lt;has_maker_and_toString> }&quot;
+          "{ StringMaker&lt;has_maker_and_toString> }"
 ==
-&quot;{ StringMaker&lt;has_maker_and_toString> }&quot;
+"{ StringMaker&lt;has_maker_and_toString> }"
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -6456,10 +6569,10 @@ there&quot;
     <TestCase name="std::pair&lt;int,std::string> -> toString">
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ToStringPair.cpp" >
         <Original>
-          Catch::toString( value ) == &quot;{ 34, \&quot;xyzzy\&quot; }&quot;
+          Catch::toString( value ) == "{ 34, \"xyzzy\" }"
         </Original>
         <Expanded>
-          &quot;{ 34, &quot;xyzzy&quot; }&quot; == &quot;{ 34, &quot;xyzzy&quot; }&quot;
+          "{ 34, "xyzzy" }" == "{ 34, "xyzzy" }"
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -6467,10 +6580,10 @@ there&quot;
     <TestCase name="std::pair&lt;int,const std::string> -> toString">
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ToStringPair.cpp" >
         <Original>
-          Catch::toString(value) == &quot;{ 34, \&quot;xyzzy\&quot; }&quot;
+          Catch::toString(value) == "{ 34, \"xyzzy\" }"
         </Original>
         <Expanded>
-          &quot;{ 34, &quot;xyzzy&quot; }&quot; == &quot;{ 34, &quot;xyzzy&quot; }&quot;
+          "{ 34, "xyzzy" }" == "{ 34, "xyzzy" }"
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -6478,12 +6591,12 @@ there&quot;
     <TestCase name="std::vector&lt;std::pair&lt;std::string,int> > -> toString">
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ToStringPair.cpp" >
         <Original>
-          Catch::toString( pr ) == &quot;{ { \&quot;green\&quot;, 55 } }&quot;
+          Catch::toString( pr ) == "{ { \"green\", 55 } }"
         </Original>
         <Expanded>
-          &quot;{ { &quot;green&quot;, 55 } }&quot;
+          "{ { "green", 55 } }"
 ==
-&quot;{ { &quot;green&quot;, 55 } }&quot;
+"{ { "green", 55 } }"
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -6491,12 +6604,12 @@ there&quot;
     <TestCase name="pair&lt;pair&lt;int,const char *,pair&lt;std::string,int> > -> toString">
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ToStringPair.cpp" >
         <Original>
-          Catch::toString( pair ) == &quot;{ { 42, \&quot;Arthur\&quot; }, { \&quot;Ford\&quot;, 24 } }&quot;
+          Catch::toString( pair ) == "{ { 42, \"Arthur\" }, { \"Ford\", 24 } }"
         </Original>
         <Expanded>
-          &quot;{ { 42, &quot;Arthur&quot; }, { &quot;Ford&quot;, 24 } }&quot;
+          "{ { 42, "Arthur" }, { "Ford", 24 } }"
 ==
-&quot;{ { 42, &quot;Arthur&quot; }, { &quot;Ford&quot;, 24 } }&quot;
+"{ { 42, "Arthur" }, { "Ford", 24 } }"
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -6504,26 +6617,26 @@ there&quot;
     <TestCase name="vector&lt;int> -> toString">
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ToStringVector.cpp" >
         <Original>
-          Catch::toString(vv) == &quot;{  }&quot;
+          Catch::toString(vv) == "{  }"
         </Original>
         <Expanded>
-          &quot;{  }&quot; == &quot;{  }&quot;
+          "{  }" == "{  }"
         </Expanded>
       </Expression>
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ToStringVector.cpp" >
         <Original>
-          Catch::toString(vv) == &quot;{ 42 }&quot;
+          Catch::toString(vv) == "{ 42 }"
         </Original>
         <Expanded>
-          &quot;{ 42 }&quot; == &quot;{ 42 }&quot;
+          "{ 42 }" == "{ 42 }"
         </Expanded>
       </Expression>
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ToStringVector.cpp" >
         <Original>
-          Catch::toString(vv) == &quot;{ 42, 250 }&quot;
+          Catch::toString(vv) == "{ 42, 250 }"
         </Original>
         <Expanded>
-          &quot;{ 42, 250 }&quot; == &quot;{ 42, 250 }&quot;
+          "{ 42, 250 }" == "{ 42, 250 }"
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -6531,28 +6644,28 @@ there&quot;
     <TestCase name="vector&lt;string> -> toString">
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ToStringVector.cpp" >
         <Original>
-          Catch::toString(vv) == &quot;{  }&quot;
+          Catch::toString(vv) == "{  }"
         </Original>
         <Expanded>
-          &quot;{  }&quot; == &quot;{  }&quot;
+          "{  }" == "{  }"
         </Expanded>
       </Expression>
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ToStringVector.cpp" >
         <Original>
-          Catch::toString(vv) == &quot;{ \&quot;hello\&quot; }&quot;
+          Catch::toString(vv) == "{ \"hello\" }"
         </Original>
         <Expanded>
-          &quot;{ &quot;hello&quot; }&quot; == &quot;{ &quot;hello&quot; }&quot;
+          "{ "hello" }" == "{ "hello" }"
         </Expanded>
       </Expression>
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ToStringVector.cpp" >
         <Original>
-          Catch::toString(vv) == &quot;{ \&quot;hello\&quot;, \&quot;world\&quot; }&quot;
+          Catch::toString(vv) == "{ \"hello\", \"world\" }"
         </Original>
         <Expanded>
-          &quot;{ &quot;hello&quot;, &quot;world&quot; }&quot;
+          "{ "hello", "world" }"
 ==
-&quot;{ &quot;hello&quot;, &quot;world&quot; }&quot;
+"{ "hello", "world" }"
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -6560,26 +6673,26 @@ there&quot;
     <TestCase name="vector&lt;int,allocator> -> toString">
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ToStringVector.cpp" >
         <Original>
-          Catch::toString(vv) == &quot;{  }&quot;
+          Catch::toString(vv) == "{  }"
         </Original>
         <Expanded>
-          &quot;{  }&quot; == &quot;{  }&quot;
+          "{  }" == "{  }"
         </Expanded>
       </Expression>
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ToStringVector.cpp" >
         <Original>
-          Catch::toString(vv) == &quot;{ 42 }&quot;
+          Catch::toString(vv) == "{ 42 }"
         </Original>
         <Expanded>
-          &quot;{ 42 }&quot; == &quot;{ 42 }&quot;
+          "{ 42 }" == "{ 42 }"
         </Expanded>
       </Expression>
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ToStringVector.cpp" >
         <Original>
-          Catch::toString(vv) == &quot;{ 42, 250 }&quot;
+          Catch::toString(vv) == "{ 42, 250 }"
         </Original>
         <Expanded>
-          &quot;{ 42, 250 }&quot; == &quot;{ 42, 250 }&quot;
+          "{ 42, 250 }" == "{ 42, 250 }"
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -6587,20 +6700,20 @@ there&quot;
     <TestCase name="vec&lt;vec&lt;string,alloc>> -> toString">
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ToStringVector.cpp" >
         <Original>
-          Catch::toString(v) == &quot;{  }&quot;
+          Catch::toString(v) == "{  }"
         </Original>
         <Expanded>
-          &quot;{  }&quot; == &quot;{  }&quot;
+          "{  }" == "{  }"
         </Expanded>
       </Expression>
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ToStringVector.cpp" >
         <Original>
-          Catch::toString(v) == &quot;{ { \&quot;hello\&quot; }, { \&quot;world\&quot; } }&quot;
+          Catch::toString(v) == "{ { \"hello\" }, { \"world\" } }"
         </Original>
         <Expanded>
-          &quot;{ { &quot;hello&quot; }, { &quot;world&quot; } }&quot;
+          "{ { "hello" }, { "world" } }"
 ==
-&quot;{ { &quot;hello&quot; }, { &quot;world&quot; } }&quot;
+"{ { "hello" }, { "world" } }"
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -6819,7 +6932,7 @@ there&quot;
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/SelfTest/CmdLineTests.cpp" >
           <Original>
-            parseTestSpec( &quot;*a&quot; ).matches( tcA ) == true
+            parseTestSpec( "*a" ).matches( tcA ) == true
           </Original>
           <Expanded>
             true == true
@@ -6870,7 +6983,7 @@ there&quot;
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/SelfTest/CmdLineTests.cpp" >
           <Original>
-            parseTestSpec( &quot;a*&quot; ).matches( tcA ) == true
+            parseTestSpec( "a*" ).matches( tcA ) == true
           </Original>
           <Expanded>
             true == true
@@ -6921,7 +7034,7 @@ there&quot;
         </Expression>
         <Expression success="true" type="CHECK" filename="projects/SelfTest/CmdLineTests.cpp" >
           <Original>
-            parseTestSpec( &quot;*a*&quot; ).matches( tcA ) == true
+            parseTestSpec( "*a*" ).matches( tcA ) == true
           </Original>
           <Expanded>
             true == true
@@ -7784,18 +7897,18 @@ there&quot;
     <TestCase name="tuple&lt;>">
       <Expression success="true" type="CHECK" filename="projects/SelfTest/ToStringTuple.cpp" >
         <Original>
-          &quot;{ }&quot; == Catch::toString(type{})
+          "{ }" == Catch::toString(type{})
         </Original>
         <Expanded>
-          &quot;{ }&quot; == &quot;{ }&quot;
+          "{ }" == "{ }"
         </Expanded>
       </Expression>
       <Expression success="true" type="CHECK" filename="projects/SelfTest/ToStringTuple.cpp" >
         <Original>
-          &quot;{ }&quot; == Catch::toString(value)
+          "{ }" == Catch::toString(value)
         </Original>
         <Expanded>
-          &quot;{ }&quot; == &quot;{ }&quot;
+          "{ }" == "{ }"
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -7803,10 +7916,10 @@ there&quot;
     <TestCase name="tuple&lt;int>">
       <Expression success="true" type="CHECK" filename="projects/SelfTest/ToStringTuple.cpp" >
         <Original>
-          &quot;{ 0 }&quot; == Catch::toString(type{0})
+          "{ 0 }" == Catch::toString(type{0})
         </Original>
         <Expanded>
-          &quot;{ 0 }&quot; == &quot;{ 0 }&quot;
+          "{ 0 }" == "{ 0 }"
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -7814,18 +7927,18 @@ there&quot;
     <TestCase name="tuple&lt;float,int>">
       <Expression success="true" type="CHECK" filename="projects/SelfTest/ToStringTuple.cpp" >
         <Original>
-          &quot;1.2f&quot; == Catch::toString(float(1.2))
+          "1.2f" == Catch::toString(float(1.2))
         </Original>
         <Expanded>
-          &quot;1.2f&quot; == &quot;1.2f&quot;
+          "1.2f" == "1.2f"
         </Expanded>
       </Expression>
       <Expression success="true" type="CHECK" filename="projects/SelfTest/ToStringTuple.cpp" >
         <Original>
-          &quot;{ 1.2f, 0 }&quot; == Catch::toString(type{1.2,0})
+          "{ 1.2f, 0 }" == Catch::toString(type{1.2,0})
         </Original>
         <Expanded>
-          &quot;{ 1.2f, 0 }&quot; == &quot;{ 1.2f, 0 }&quot;
+          "{ 1.2f, 0 }" == "{ 1.2f, 0 }"
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -7833,12 +7946,12 @@ there&quot;
     <TestCase name="tuple&lt;string,string>">
       <Expression success="true" type="CHECK" filename="projects/SelfTest/ToStringTuple.cpp" >
         <Original>
-          &quot;{ \&quot;hello\&quot;, \&quot;world\&quot; }&quot; == Catch::toString(type{&quot;hello&quot;,&quot;world&quot;})
+          "{ \"hello\", \"world\" }" == Catch::toString(type{"hello","world"})
         </Original>
         <Expanded>
-          &quot;{ &quot;hello&quot;, &quot;world&quot; }&quot;
+          "{ "hello", "world" }"
 ==
-&quot;{ &quot;hello&quot;, &quot;world&quot; }&quot;
+"{ "hello", "world" }"
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -7846,12 +7959,12 @@ there&quot;
     <TestCase name="tuple&lt;tuple&lt;int>,tuple&lt;>,float>">
       <Expression success="true" type="CHECK" filename="projects/SelfTest/ToStringTuple.cpp" >
         <Original>
-          &quot;{ { 42 }, { }, 1.2f }&quot; == Catch::toString(value)
+          "{ { 42 }, { }, 1.2f }" == Catch::toString(value)
         </Original>
         <Expanded>
-          &quot;{ { 42 }, { }, 1.2f }&quot;
+          "{ { 42 }, { }, 1.2f }"
 ==
-&quot;{ { 42 }, { }, 1.2f }&quot;
+"{ { 42 }, { }, 1.2f }"
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -7859,12 +7972,12 @@ there&quot;
     <TestCase name="tuple&lt;nullptr,int,const char *>">
       <Expression success="true" type="CHECK" filename="projects/SelfTest/ToStringTuple.cpp" >
         <Original>
-          &quot;{ nullptr, 42, \&quot;Catch me\&quot; }&quot; == Catch::toString(value)
+          "{ nullptr, 42, \"Catch me\" }" == Catch::toString(value)
         </Original>
         <Expanded>
-          &quot;{ nullptr, 42, &quot;Catch me&quot; }&quot;
+          "{ nullptr, 42, "Catch me" }"
 ==
-&quot;{ nullptr, 42, &quot;Catch me&quot; }&quot;
+"{ nullptr, 42, "Catch me" }"
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -7873,42 +7986,42 @@ there&quot;
       <Section name="The same tag alias can only be registered once">
         <Expression success="true" type="CHECK_THAT" filename="projects/SelfTest/TagAliasTests.cpp" >
           <Original>
-            what Contains( &quot;[@zzz]&quot; )
+            what Contains( "[@zzz]" )
           </Original>
           <Expanded>
-            &quot;error: tag alias, &quot;[@zzz]&quot; already registered.
+            "error: tag alias, "[@zzz]" already registered.
 	First seen at file:2
-	Redefined at file:10&quot; contains: &quot;[@zzz]&quot;
+	Redefined at file:10" contains: "[@zzz]"
           </Expanded>
         </Expression>
         <Expression success="true" type="CHECK_THAT" filename="projects/SelfTest/TagAliasTests.cpp" >
           <Original>
-            what Contains( &quot;file&quot; )
+            what Contains( "file" )
           </Original>
           <Expanded>
-            &quot;error: tag alias, &quot;[@zzz]&quot; already registered.
+            "error: tag alias, "[@zzz]" already registered.
 	First seen at file:2
-	Redefined at file:10&quot; contains: &quot;file&quot;
+	Redefined at file:10" contains: "file"
           </Expanded>
         </Expression>
         <Expression success="true" type="CHECK_THAT" filename="projects/SelfTest/TagAliasTests.cpp" >
           <Original>
-            what Contains( &quot;2&quot; )
+            what Contains( "2" )
           </Original>
           <Expanded>
-            &quot;error: tag alias, &quot;[@zzz]&quot; already registered.
+            "error: tag alias, "[@zzz]" already registered.
 	First seen at file:2
-	Redefined at file:10&quot; contains: &quot;2&quot;
+	Redefined at file:10" contains: "2"
           </Expanded>
         </Expression>
         <Expression success="true" type="CHECK_THAT" filename="projects/SelfTest/TagAliasTests.cpp" >
           <Original>
-            what Contains( &quot;10&quot; )
+            what Contains( "10" )
           </Original>
           <Expanded>
-            &quot;error: tag alias, &quot;[@zzz]&quot; already registered.
+            "error: tag alias, "[@zzz]" already registered.
 	First seen at file:2
-	Redefined at file:10&quot; contains: &quot;10&quot;
+	Redefined at file:10" contains: "10"
           </Expanded>
         </Expression>
         <OverallResults successes="4" failures="0" expectedFailures="0"/>
@@ -7916,34 +8029,34 @@ there&quot;
       <Section name="Tag aliases must be of the form [@name]">
         <Expression success="true" type="CHECK_THROWS" filename="projects/SelfTest/TagAliasTests.cpp" >
           <Original>
-            registry.add( &quot;[no ampersat]&quot;, &quot;&quot;, Catch::SourceLineInfo( &quot;file&quot;, 3 ) )
+            registry.add( "[no ampersat]", "", Catch::SourceLineInfo( "file", 3 ) )
           </Original>
           <Expanded>
-            registry.add( &quot;[no ampersat]&quot;, &quot;&quot;, Catch::SourceLineInfo( &quot;file&quot;, 3 ) )
+            registry.add( "[no ampersat]", "", Catch::SourceLineInfo( "file", 3 ) )
           </Expanded>
         </Expression>
         <Expression success="true" type="CHECK_THROWS" filename="projects/SelfTest/TagAliasTests.cpp" >
           <Original>
-            registry.add( &quot;[the @ is not at the start]&quot;, &quot;&quot;, Catch::SourceLineInfo( &quot;file&quot;, 3 ) )
+            registry.add( "[the @ is not at the start]", "", Catch::SourceLineInfo( "file", 3 ) )
           </Original>
           <Expanded>
-            registry.add( &quot;[the @ is not at the start]&quot;, &quot;&quot;, Catch::SourceLineInfo( &quot;file&quot;, 3 ) )
+            registry.add( "[the @ is not at the start]", "", Catch::SourceLineInfo( "file", 3 ) )
           </Expanded>
         </Expression>
         <Expression success="true" type="CHECK_THROWS" filename="projects/SelfTest/TagAliasTests.cpp" >
           <Original>
-            registry.add( &quot;@no square bracket at start]&quot;, &quot;&quot;, Catch::SourceLineInfo( &quot;file&quot;, 3 ) )
+            registry.add( "@no square bracket at start]", "", Catch::SourceLineInfo( "file", 3 ) )
           </Original>
           <Expanded>
-            registry.add( &quot;@no square bracket at start]&quot;, &quot;&quot;, Catch::SourceLineInfo( &quot;file&quot;, 3 ) )
+            registry.add( "@no square bracket at start]", "", Catch::SourceLineInfo( "file", 3 ) )
           </Expanded>
         </Expression>
         <Expression success="true" type="CHECK_THROWS" filename="projects/SelfTest/TagAliasTests.cpp" >
           <Original>
-            registry.add( &quot;[@no square bracket at end&quot;, &quot;&quot;, Catch::SourceLineInfo( &quot;file&quot;, 3 ) )
+            registry.add( "[@no square bracket at end", "", Catch::SourceLineInfo( "file", 3 ) )
           </Original>
           <Expanded>
-            registry.add( &quot;[@no square bracket at end&quot;, &quot;&quot;, Catch::SourceLineInfo( &quot;file&quot;, 3 ) )
+            registry.add( "[@no square bracket at end", "", Catch::SourceLineInfo( "file", 3 ) )
           </Expanded>
         </Expression>
         <OverallResults successes="4" failures="0" expectedFailures="0"/>
@@ -8299,7 +8412,7 @@ there&quot;
       </Section>
       <OverallResult success="true"/>
     </TestCase>
-    <OverallResults successes="680" failures="100" expectedFailures="13"/>
+    <OverallResults successes="690" failures="100" expectedFailures="13"/>
   </Group>
-  <OverallResults successes="680" failures="100" expectedFailures="13"/>
+  <OverallResults successes="690" failures="100" expectedFailures="13"/>
 </Catch>

--- a/projects/SelfTest/Baselines/xml.sw.approved.txt
+++ b/projects/SelfTest/Baselines/xml.sw.approved.txt
@@ -1596,6 +1596,25 @@
       </Expression>
       <OverallResult success="true"/>
     </TestCase>
+    <TestCase name="Exception messages can be tested for">
+      <Expression success="true" type="REQUIRE_THROWS_WITH" filename="projects/SelfTest/ExceptionTests.cpp" >
+        <Original>
+          thisThrows(), &quot;expected exception&quot;
+        </Original>
+        <Expanded>
+          thisThrows(), &quot;expected exception&quot;
+        </Expanded>
+      </Expression>
+      <Expression success="false" type="REQUIRE_THROWS_WITH" filename="projects/SelfTest/ExceptionTests.cpp" >
+        <Original>
+          thisThrows(), &quot;should fail&quot;
+        </Original>
+        <Expanded>
+          expected exception
+        </Expanded>
+      </Expression>
+      <OverallResult success="false"/>
+    </TestCase>
     <TestCase name="Generators over two ranges">
       <Expression success="true" type="CATCH_REQUIRE" filename="projects/SelfTest/GeneratorTests.cpp" >
         <Original>
@@ -8220,7 +8239,7 @@ there&quot;
       </Section>
       <OverallResult success="true"/>
     </TestCase>
-    <OverallResults successes="673" failures="99" expectedFailures="13"/>
+    <OverallResults successes="674" failures="100" expectedFailures="13"/>
   </Group>
-  <OverallResults successes="673" failures="99" expectedFailures="13"/>
+  <OverallResults successes="674" failures="100" expectedFailures="13"/>
 </Catch>

--- a/projects/SelfTest/Baselines/xml.sw.approved.txt
+++ b/projects/SelfTest/Baselines/xml.sw.approved.txt
@@ -1063,9 +1063,7 @@
           (std::numeric_limits&lt;unsigned long>::max)() > ul
         </Original>
         <Expanded>
-          18446744073709551615 (0x<hex digits>)
->
-4
+          4294967295 (0x<hex digits>) > 4
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -3964,6 +3962,19 @@
       </Section>
       <OverallResult success="true"/>
     </TestCase>
+    <TestCase name="long long">
+      <Expression success="true" type="REQUIRE" filename="projects/SelfTest/MiscTests.cpp" >
+        <Original>
+          l == std::numeric_limits&lt;long long>::max()
+        </Original>
+        <Expanded>
+          9223372036854775807 (0x<hex digits>)
+==
+9223372036854775807 (0x<hex digits>)
+        </Expanded>
+      </Expression>
+      <OverallResult success="true"/>
+    </TestCase>
     <TestCase name="Process can be configured on command line">
       <Section name="default - no arguments">
         <Expression success="true" type="CHECK_NOTHROW" filename="projects/SelfTest/TestMain.cpp" >
@@ -6449,9 +6460,7 @@ there"
           m == &amp;S::f
         </Original>
         <Expanded>
-          0x<hex digits>
-==
-0x<hex digits>
+          0x<hex digits> == 0x<hex digits>
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -8412,7 +8421,7 @@ there"
       </Section>
       <OverallResult success="true"/>
     </TestCase>
-    <OverallResults successes="690" failures="100" expectedFailures="13"/>
+    <OverallResults successes="691" failures="100" expectedFailures="13"/>
   </Group>
-  <OverallResults successes="690" failures="100" expectedFailures="13"/>
+  <OverallResults successes="691" failures="100" expectedFailures="13"/>
 </Catch>

--- a/projects/SelfTest/Baselines/xml.sw.approved.txt
+++ b/projects/SelfTest/Baselines/xml.sw.approved.txt
@@ -1205,10 +1205,10 @@
     <TestCase name="Pointers can be compared to null">
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ConditionTests.cpp" >
         <Original>
-          p == __null
+          p == nullptr
         </Original>
         <Expanded>
-          __null == 0
+          NULL == nullptr
         </Expanded>
       </Expression>
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ConditionTests.cpp" >
@@ -1216,55 +1216,55 @@
           p == pNULL
         </Original>
         <Expanded>
-          __null == __null
+          NULL == NULL
         </Expanded>
       </Expression>
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ConditionTests.cpp" >
         <Original>
-          p != __null
+          p != nullptr
         </Original>
         <Expanded>
-          0x<hex digits> != 0
+          0x<hex digits> != nullptr
         </Expanded>
       </Expression>
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ConditionTests.cpp" >
         <Original>
-          cp != __null
+          cp != nullptr
         </Original>
         <Expanded>
-          0x<hex digits> != 0
+          0x<hex digits> != nullptr
         </Expanded>
       </Expression>
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ConditionTests.cpp" >
         <Original>
-          cpc != __null
+          cpc != nullptr
         </Original>
         <Expanded>
-          0x<hex digits> != 0
+          0x<hex digits> != nullptr
         </Expanded>
       </Expression>
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ConditionTests.cpp" >
         <Original>
-          returnsNull() == __null
+          returnsNull() == nullptr
         </Original>
         <Expanded>
-          {null string} == 0
+          {null string} == nullptr
         </Expanded>
       </Expression>
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ConditionTests.cpp" >
         <Original>
-          returnsConstNull() == __null
+          returnsConstNull() == nullptr
         </Original>
         <Expanded>
-          {null string} == 0
+          {null string} == nullptr
         </Expanded>
       </Expression>
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/ConditionTests.cpp" >
         <Original>
-          __null != p
+          nullptr != p
         </Original>
         <Expanded>
-          0 != 0x<hex digits>
+          nullptr != 0x<hex digits>
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -3226,7 +3226,7 @@
     <TestCase name="null strings">
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/MiscTests.cpp" >
         <Original>
-          makeString( false ) != static_cast&lt;char*>(__null)
+          makeString( false ) != static_cast&lt;char*>(nullptr)
         </Original>
         <Expanded>
           &quot;valid string&quot; != {null string}
@@ -3234,7 +3234,7 @@
       </Expression>
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/MiscTests.cpp" >
         <Original>
-          makeString( true ) == static_cast&lt;char*>(__null)
+          makeString( true ) == static_cast&lt;char*>(nullptr)
         </Original>
         <Expanded>
           {null string} == {null string}
@@ -3434,7 +3434,7 @@
     <TestCase name="Equals string matcher, with NULL">
       <Expression success="true" type="REQUIRE_THAT" filename="projects/SelfTest/MiscTests.cpp" >
         <Original>
-          &quot;&quot; Equals(__null)
+          &quot;&quot; Equals(nullptr)
         </Original>
         <Expanded>
           &quot;&quot; equals: &quot;&quot;
@@ -6041,10 +6041,10 @@ there&quot;
     <TestCase name="boolean member">
       <Expression success="true" type="REQUIRE" filename="projects/SelfTest/TrickyTests.cpp" >
         <Original>
-          obj.prop != __null
+          obj.prop != nullptr
         </Original>
         <Expanded>
-          0x<hex digits> != 0
+          0x<hex digits> != nullptr
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -6270,7 +6270,7 @@ there&quot;
           p == 0
         </Original>
         <Expanded>
-          __null == 0
+          NULL == 0
         </Expanded>
       </Expression>
       <OverallResult success="true"/>
@@ -6281,7 +6281,7 @@ there&quot;
           ptr.get() == nullptr
         </Original>
         <Expanded>
-          __null == nullptr
+          NULL == nullptr
         </Expanded>
       </Expression>
       <OverallResult success="true"/>

--- a/projects/SelfTest/CmdLineTests.cpp
+++ b/projects/SelfTest/CmdLineTests.cpp
@@ -9,6 +9,9 @@
 #include "catch.hpp"
 #include "catch_test_spec_parser.hpp"
 
+#ifdef __clang__
+#   pragma clang diagnostic ignored "-Wc++98-compat"
+#endif
 
 inline Catch::TestCase fakeTestCase( const char* name, const char* desc = "" ){ return Catch::makeTestCase( CATCH_NULL, "", name, desc, CATCH_INTERNAL_LINEINFO ); }
 

--- a/projects/SelfTest/CmdLineTests.cpp
+++ b/projects/SelfTest/CmdLineTests.cpp
@@ -10,7 +10,7 @@
 #include "catch_test_spec_parser.hpp"
 
 
-inline Catch::TestCase fakeTestCase( const char* name, const char* desc = "" ){ return Catch::makeTestCase( NULL, "", name, desc, CATCH_INTERNAL_LINEINFO ); }
+inline Catch::TestCase fakeTestCase( const char* name, const char* desc = "" ){ return Catch::makeTestCase( CATCH_NULL, "", name, desc, CATCH_INTERNAL_LINEINFO ); }
 
 TEST_CASE( "Parse test names and tags", "" ) {
 

--- a/projects/SelfTest/ConditionTests.cpp
+++ b/projects/SelfTest/ConditionTests.cpp
@@ -265,32 +265,32 @@ TEST_CASE( "Comparisons between ints where one side is computed", "" )
 #pragma GCC diagnostic pop
 #endif
 
-inline const char* returnsConstNull(){ return NULL; }
-inline char* returnsNull(){ return NULL; }
+inline const char* returnsConstNull(){ return CATCH_NULL; }
+inline char* returnsNull(){ return CATCH_NULL; }
 
 TEST_CASE( "Pointers can be compared to null", "" )
 {
-    TestData* p = NULL;
-    TestData* pNULL = NULL;
+    TestData* p = CATCH_NULL;
+    TestData* pNULL = CATCH_NULL;
     
-    REQUIRE( p == NULL );
+    REQUIRE( p == CATCH_NULL );
     REQUIRE( p == pNULL );
     
     TestData data;
     p = &data;
     
-    REQUIRE( p != NULL );
+    REQUIRE( p != CATCH_NULL );
 
     const TestData* cp = p;
-    REQUIRE( cp != NULL );
+    REQUIRE( cp != CATCH_NULL );
 
     const TestData* const cpc = p;
-    REQUIRE( cpc != NULL );
+    REQUIRE( cpc != CATCH_NULL );
 
-    REQUIRE( returnsNull() == NULL );
-    REQUIRE( returnsConstNull() == NULL );
+    REQUIRE( returnsNull() == CATCH_NULL );
+    REQUIRE( returnsConstNull() == CATCH_NULL );
     
-    REQUIRE( NULL != p );
+    REQUIRE( CATCH_NULL != p );
 }
 
 // Not (!) tests

--- a/projects/SelfTest/ConditionTests.cpp
+++ b/projects/SelfTest/ConditionTests.cpp
@@ -6,7 +6,8 @@
  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
  */
 #ifdef __clang__
-#pragma clang diagnostic ignored "-Wpadded"
+#   pragma clang diagnostic ignored "-Wpadded"
+#   pragma clang diagnostic ignored "-Wc++98-compat"
 #endif
 
 #include "catch.hpp"

--- a/projects/SelfTest/ExceptionTests.cpp
+++ b/projects/SelfTest/ExceptionTests.cpp
@@ -152,3 +152,8 @@ TEST_CASE( "NotImplemented exception", "" )
 {
     REQUIRE_THROWS( thisFunctionNotImplemented( 7 ) );
 }
+
+TEST_CASE( "Exception messages can be tested for", "[.][failing]" ) {
+    REQUIRE_THROWS_WITH( thisThrows(), "expected exception" );
+    REQUIRE_THROWS_WITH( thisThrows(), "should fail" );
+}

--- a/projects/SelfTest/ExceptionTests.cpp
+++ b/projects/SelfTest/ExceptionTests.cpp
@@ -153,7 +153,21 @@ TEST_CASE( "NotImplemented exception", "" )
     REQUIRE_THROWS( thisFunctionNotImplemented( 7 ) );
 }
 
-TEST_CASE( "Exception messages can be tested for", "[.][failing]" ) {
+TEST_CASE( "Exception messages can be tested for", "" ) {
+    SECTION( "exact match" )
+        REQUIRE_THROWS_WITH( thisThrows(), "expected exception" );
+    SECTION( "different case" )
+        REQUIRE_THROWS_WITH( thisThrows(), "expecteD Exception" );
+    SECTION( "wildcarded" ) {
+        REQUIRE_THROWS_WITH( thisThrows(), "expected*" );
+        REQUIRE_THROWS_WITH( thisThrows(), "*exception" );
+        REQUIRE_THROWS_WITH( thisThrows(), "*except*" );
+        REQUIRE_THROWS_WITH( thisThrows(), "*exCept*" );
+    }
+}
+
+TEST_CASE( "Mismatching exception messages failing the test", "[.][failing]" ) {
+    REQUIRE_THROWS_WITH( thisThrows(), "expected exception" );
     REQUIRE_THROWS_WITH( thisThrows(), "expected exception" );
     REQUIRE_THROWS_WITH( thisThrows(), "should fail" );
 }

--- a/projects/SelfTest/ExceptionTests.cpp
+++ b/projects/SelfTest/ExceptionTests.cpp
@@ -154,20 +154,21 @@ TEST_CASE( "NotImplemented exception", "" )
 }
 
 TEST_CASE( "Exception messages can be tested for", "" ) {
+    using namespace Catch::Matchers;
     SECTION( "exact match" )
         REQUIRE_THROWS_WITH( thisThrows(), "expected exception" );
     SECTION( "different case" )
-        REQUIRE_THROWS_WITH( thisThrows(), "expecteD Exception" );
+    REQUIRE_THROWS_WITH( thisThrows(), Equals( "expecteD Exception", Catch::CaseSensitive::No ) );
     SECTION( "wildcarded" ) {
-        REQUIRE_THROWS_WITH( thisThrows(), "expected*" );
-        REQUIRE_THROWS_WITH( thisThrows(), "*exception" );
-        REQUIRE_THROWS_WITH( thisThrows(), "*except*" );
-        REQUIRE_THROWS_WITH( thisThrows(), "*exCept*" );
+        REQUIRE_THROWS_WITH( thisThrows(), StartsWith( "expected" ) );
+        REQUIRE_THROWS_WITH( thisThrows(), EndsWith( "exception" ) );
+        REQUIRE_THROWS_WITH( thisThrows(), Contains( "except" ) );
+        REQUIRE_THROWS_WITH( thisThrows(), Contains( "exCept", Catch::CaseSensitive::No ) );
     }
 }
 
 TEST_CASE( "Mismatching exception messages failing the test", "[.][failing]" ) {
     REQUIRE_THROWS_WITH( thisThrows(), "expected exception" );
-    REQUIRE_THROWS_WITH( thisThrows(), "expected exception" );
     REQUIRE_THROWS_WITH( thisThrows(), "should fail" );
+    REQUIRE_THROWS_WITH( thisThrows(), "expected exception" );
 }

--- a/projects/SelfTest/MiscTests.cpp
+++ b/projects/SelfTest/MiscTests.cpp
@@ -418,6 +418,14 @@ TEST_CASE( "XmlEncode" ) {
     }
 }
 
+#ifdef CATCH_CONFIG_CPP11_LONG_LONG
+TEST_CASE( "long long" ) {
+    long long l = std::numeric_limits<long long>::max();
+    
+    REQUIRE( l == std::numeric_limits<long long>::max() );
+}
+#endif
+
 //TEST_CASE( "Divide by Zero signal handler", "[.][sig]" ) {
 //    int i = 0;
 //    int x = 10/i; // This should cause the signal to fire

--- a/projects/SelfTest/MiscTests.cpp
+++ b/projects/SelfTest/MiscTests.cpp
@@ -124,13 +124,13 @@ TEST_CASE( "Sends stuff to stdout and stderr", "[.]" )
 
 inline const char* makeString( bool makeNull )
 {
-    return makeNull ? NULL : "valid string";
+    return makeNull ? CATCH_NULL : "valid string";
 }
 
 TEST_CASE( "null strings", "" )
 {
-    REQUIRE( makeString( false ) != static_cast<char*>(NULL));
-    REQUIRE( makeString( true ) == static_cast<char*>(NULL));
+    REQUIRE( makeString( false ) != static_cast<char*>(CATCH_NULL));
+    REQUIRE( makeString( true ) == static_cast<char*>(CATCH_NULL));
 }
 
 
@@ -233,7 +233,7 @@ TEST_CASE("Equals string matcher", "[.][failing][matchers]")
 }
 TEST_CASE("Equals string matcher, with NULL", "[matchers]")
 {
-    REQUIRE_THAT("", Equals(NULL));
+    REQUIRE_THAT("", Equals(CATCH_NULL));
 }
 TEST_CASE("AllOf matcher", "[matchers]")
 {

--- a/projects/SelfTest/MiscTests.cpp
+++ b/projects/SelfTest/MiscTests.cpp
@@ -7,7 +7,7 @@
  */
 
 #include "catch.hpp"
-#include "catch_xmlwriter.hpp"
+#include "internal/catch_xmlwriter.hpp"
 
 #include <iostream>
 

--- a/projects/SelfTest/MiscTests.cpp
+++ b/projects/SelfTest/MiscTests.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "catch.hpp"
+#include "catch_xmlwriter.hpp"
 
 #include <iostream>
 
@@ -379,6 +380,42 @@ TEST_CASE( "toString on wchar_t returns the string contents", "[toString]" ) {
 	wchar_t * s = const_cast<wchar_t*>( L"wide load" );
 	std::string result = Catch::toString( s );
 	CHECK( result == "\"wide load\"" );
+}
+
+inline std::string encode( std::string const& str, Catch::XmlEncode::ForWhat forWhat = Catch::XmlEncode::ForTextNodes ) {
+    std::ostringstream oss;
+    oss << Catch::XmlEncode( str, forWhat );
+    return oss.str();
+}
+
+TEST_CASE( "XmlEncode" ) {
+    SECTION( "normal string" ) {
+        REQUIRE( encode( "normal string" ) == "normal string" );
+    }
+    SECTION( "empty string" ) {
+        REQUIRE( encode( "" ) == "" );
+    }
+    SECTION( "string with ampersand" ) {
+        REQUIRE( encode( "smith & jones" ) == "smith &amp; jones" );
+    }
+    SECTION( "string with less-than" ) {
+        REQUIRE( encode( "smith < jones" ) == "smith &lt; jones" );
+    }
+    SECTION( "string with greater-than" ) {
+        REQUIRE( encode( "smith > jones" ) == "smith > jones" );
+        REQUIRE( encode( "smith ]]> jones" ) == "smith ]]&gt; jones" );
+    }
+    SECTION( "string with quotes" ) {
+        std::string stringWithQuotes = "don't \"quote\" me on that";
+        REQUIRE( encode( stringWithQuotes ) == stringWithQuotes );
+        REQUIRE( encode( stringWithQuotes, Catch::XmlEncode::ForAttributes ) == "don't &quot;quote&quot; me on that" );
+    }
+    SECTION( "string with control char (1)" ) {
+        REQUIRE( encode( "[\x01]" ) == "[&#x1]" );
+    }
+    SECTION( "string with control char (x7F)" ) {
+        REQUIRE( encode( "[\x7F]" ) == "[&#x7F]" );
+    }
 }
 
 //TEST_CASE( "Divide by Zero signal handler", "[.][sig]" ) {

--- a/projects/SelfTest/SectionTrackerTests.cpp
+++ b/projects/SelfTest/SectionTrackerTests.cpp
@@ -7,7 +7,8 @@
  */
 
 #ifdef __clang__
-#pragma clang diagnostic ignored "-Wpadded"
+#   pragma clang diagnostic ignored "-Wpadded"
+#   pragma clang diagnostic ignored "-Wc++98-compat"
 #endif
 
 #include "internal/catch_test_case_tracker.hpp"

--- a/projects/SelfTest/SurrogateCpps/catch_xmlwriter.cpp
+++ b/projects/SelfTest/SurrogateCpps/catch_xmlwriter.cpp
@@ -1,2 +1,4 @@
 // This file is only here to verify (to the extent possible) the self sufficiency of the header
+#include "catch_suppress_warnings.h"
 #include "catch_xmlwriter.hpp"
+#include "catch_reenable_warnings.h"

--- a/projects/SelfTest/TestMain.cpp
+++ b/projects/SelfTest/TestMain.cpp
@@ -39,7 +39,7 @@ std::string parseIntoConfigAndReturnError( const char * (&argv)[size], Catch::Co
     return "";
 }
 
-inline Catch::TestCase fakeTestCase( const char* name, const char* desc = "" ){ return Catch::makeTestCase( NULL, "", name, desc, CATCH_INTERNAL_LINEINFO ); }
+inline Catch::TestCase fakeTestCase( const char* name, const char* desc = "" ){ return Catch::makeTestCase( CATCH_NULL, "", name, desc, CATCH_INTERNAL_LINEINFO ); }
 
 TEST_CASE( "Process can be configured on command line", "[config][command-line]" ) {
 

--- a/projects/SelfTest/TestMain.cpp
+++ b/projects/SelfTest/TestMain.cpp
@@ -16,8 +16,9 @@ CATCH_REGISTER_TAG_ALIAS( "[@tricky]", "[tricky]~[.]" )
 
 
 #ifdef __clang__
-#pragma clang diagnostic ignored "-Wpadded"
-#pragma clang diagnostic ignored "-Wweak-vtables"
+#   pragma clang diagnostic ignored "-Wpadded"
+#   pragma clang diagnostic ignored "-Wweak-vtables"
+#   pragma clang diagnostic ignored "-Wc++98-compat"
 #endif
 
 

--- a/projects/SelfTest/ToStringTuple.cpp
+++ b/projects/SelfTest/ToStringTuple.cpp
@@ -42,12 +42,14 @@ TEST_CASE( "tuple<tuple<int>,tuple<>,float>", "[toString][tuple]" )
     CHECK( "{ { 42 }, { }, 1.2f }" == Catch::toString(value) );
 }
 
+#ifdef CATCH_CONFIG_CPP11_NULLPTR
 TEST_CASE( "tuple<nullptr,int,const char *>", "[toString][tuple]" )
 {
     typedef std::tuple<std::nullptr_t,int,const char *> type;
     type value { nullptr, 42, "Catch me" };
     CHECK( "{ nullptr, 42, \"Catch me\" }" == Catch::toString(value) );
 }
+#endif
 
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/projects/SelfTest/TrickyTests.cpp
+++ b/projects/SelfTest/TrickyTests.cpp
@@ -234,7 +234,7 @@ struct Obj
 TEST_CASE("boolean member", "[Tricky]")
 {
     Obj obj;
-    REQUIRE( obj.prop != NULL );
+    REQUIRE( obj.prop != CATCH_NULL );
 }
 
 // Tests for a problem submitted by Ralph McArdell

--- a/projects/XCode/CatchSelfTest/CatchSelfTest.xcodeproj/project.pbxproj
+++ b/projects/XCode/CatchSelfTest/CatchSelfTest.xcodeproj/project.pbxproj
@@ -91,7 +91,6 @@
 		26711C91195D47820033EDA2 /* catch_tag_alias.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = catch_tag_alias.h; sourceTree = "<group>"; };
 		26711C92195D48F60033EDA2 /* catch_tag_alias_registry.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = catch_tag_alias_registry.hpp; sourceTree = "<group>"; };
 		26711C94195D4B120033EDA2 /* catch_tag_alias_registry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = catch_tag_alias_registry.h; sourceTree = "<group>"; };
-		26759472171C72A400A84BD1 /* catch_sfinae.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; lineEnding = 0; path = catch_sfinae.hpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
 		26759473171C74C200A84BD1 /* catch_compiler_capabilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = catch_compiler_capabilities.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		26847E5B16BBAB790043B9C1 /* catch_message.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = catch_message.h; sourceTree = "<group>"; };
 		26847E5C16BBACB60043B9C1 /* catch_message.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = catch_message.hpp; sourceTree = "<group>"; };
@@ -453,6 +452,7 @@
 				266ECD8C1713614B0030D735 /* catch_legacy_reporter_adapter.hpp */,
 				266ECD8D1713614B0030D735 /* catch_legacy_reporter_adapter.h */,
 				4A6D0C49149B3E3D00DB3EAA /* catch_common.h */,
+				262E739A1846759000CAC268 /* catch_common.hpp */,
 				4A6D0C4B149B3E3D00DB3EAA /* catch_debugger.hpp */,
 				261488FF184DC4A20041FBEB /* catch_debugger.h */,
 				4A6D0C60149B3E3D00DB3EAA /* catch_stream.hpp */,
@@ -461,12 +461,10 @@
 				4AB77CB51551AEA200857BF0 /* catch_ptr.hpp */,
 				4AEE0326161431070071E950 /* catch_streambuf.h */,
 				4ACE21C8166CA19700FB5509 /* catch_option.hpp */,
-				26759472171C72A400A84BD1 /* catch_sfinae.hpp */,
 				26759473171C74C200A84BD1 /* catch_compiler_capabilities.h */,
 				26DACF2F17206D3400A21326 /* catch_text.h */,
 				263FD06117AF8DF200988A20 /* catch_timer.h */,
 				26AEAF1617BEA18E009E32C9 /* catch_platform.h */,
-				262E739A1846759000CAC268 /* catch_common.hpp */,
 				261488FC184D1DC10041FBEB /* catch_stream.h */,
 				268F47B018A93F7800D8C14F /* catch_clara.h */,
 				2656C226192A77EF0040DB02 /* catch_suppress_warnings.h */,

--- a/projects/XCode/CatchSelfTest/CatchSelfTest.xcodeproj/project.pbxproj
+++ b/projects/XCode/CatchSelfTest/CatchSelfTest.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		269831E719121CA500BB0CE0 /* catch_reporter_compact.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = catch_reporter_compact.hpp; sourceTree = "<group>"; };
 		26AEAF1617BEA18E009E32C9 /* catch_platform.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = catch_platform.h; sourceTree = "<group>"; };
 		26DACF2F17206D3400A21326 /* catch_text.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = catch_text.h; sourceTree = "<group>"; };
+		26DFD3B11B53F84700FD6F16 /* catch_wildcard_pattern.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = catch_wildcard_pattern.hpp; sourceTree = "<group>"; };
 		26E1B7D119213BC900812682 /* CmdLineTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CmdLineTests.cpp; path = ../../../SelfTest/CmdLineTests.cpp; sourceTree = "<group>"; };
 		4A084F1C15DACEEA0027E631 /* catch_test_case_info.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = catch_test_case_info.hpp; sourceTree = "<group>"; };
 		4A3D7DD01503869D005F9203 /* catch_matchers.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = catch_matchers.hpp; sourceTree = "<group>"; };
@@ -470,6 +471,7 @@
 				2656C226192A77EF0040DB02 /* catch_suppress_warnings.h */,
 				2656C227192A78410040DB02 /* catch_reenable_warnings.h */,
 				263F7A4519A66608009474C2 /* catch_fatal_condition.hpp */,
+				26DFD3B11B53F84700FD6F16 /* catch_wildcard_pattern.hpp */,
 			);
 			name = Infrastructure;
 			sourceTree = "<group>";

--- a/scripts/approvalTests.py
+++ b/scripts/approvalTests.py
@@ -15,7 +15,8 @@ pathParser = re.compile( r'(.*?)/(.*\..pp)(.*)' )
 lineNumberParser = re.compile( r'(.*)line="[0-9]*"(.*)' )
 hexParser = re.compile( r'(.*)\b(0[xX][0-9a-fA-F]+)\b(.*)' )
 durationsParser = re.compile( r'(.*)time="[0-9]*\.[0-9]*"(.*)' )
-versionParser = re.compile( r'(.*?)Catch v[0-9]*\.[0-9]*\.[0-9].?( .*)' )
+versionParser = re.compile( r'(.*?)Catch v[0-9]*\.[0-9]*\.[0-9]*(.*)' )
+devVersionParser = re.compile( r'(.*?)Catch v[0-9]*\.[0-9]*\.[0-9]*-develop\.[0-9]*(.*)' )
 
 if len(sys.argv) == 2:
 	cmdPath = sys.argv[1]
@@ -41,9 +42,13 @@ def filterLine( line ):
 		if path.startswith( catchPath ):
 			path = path[1+len(catchPath):]
 		line = m.group(1) + path + m.group(3)
-	m = versionParser.match( line )
+	m = devVersionParser.match( line )
 	if m:
 		line = m.group(1) + "<version>" + m.group(2)
+	else:
+		m = versionParser.match( line )
+		if m:
+			line = m.group(1) + "<version>" + m.group(2)
 
 	while True:
 		m = hexParser.match( line )

--- a/single_include/catch.hpp
+++ b/single_include/catch.hpp
@@ -1,6 +1,6 @@
 /*
- *  Catch v1.2.1-develop.6
- *  Generated: 2015-07-13 06:35:13.441019
+ *  Catch v1.2.1-develop.7
+ *  Generated: 2015-07-13 15:03:15.644872
  *  ----------------------------------------------------------
  *  This file has been merged from multiple headers. Please don't edit it directly
  *  Copyright (c) 2012 Two Blue Cubes Ltd. All rights reserved.
@@ -2838,6 +2838,71 @@ return @ desc; \
 #pragma clang diagnostic ignored "-Wpadded"
 #endif
 
+// #included from: catch_wildcard_pattern.hpp
+#define TWOBLUECUBES_CATCH_WILDCARD_PATTERN_HPP_INCLUDED
+
+namespace Catch
+{
+    class WildcardPattern {
+        enum WildcardPosition {
+            NoWildcard = 0,
+            WildcardAtStart = 1,
+            WildcardAtEnd = 2,
+            WildcardAtBothEnds = WildcardAtStart | WildcardAtEnd
+        };
+
+    public:
+
+        enum CaseSensitivity {
+            CaseSensitive,
+            CaseInsensitive
+        };
+        WildcardPattern( std::string const& pattern, CaseSensitivity caseSensitivity )
+        :   m_caseSensitivity( caseSensitivity ),
+            m_wildcard( NoWildcard ),
+            m_pattern( adjustCase( pattern ) )
+        {
+            if( startsWith( m_pattern, "*" ) ) {
+                m_pattern = m_pattern.substr( 1 );
+                m_wildcard = WildcardAtStart;
+            }
+            if( endsWith( m_pattern, "*" ) ) {
+                m_pattern = m_pattern.substr( 0, m_pattern.size()-1 );
+                m_wildcard = static_cast<WildcardPosition>( m_wildcard | WildcardAtEnd );
+            }
+        }
+        virtual ~WildcardPattern();
+        virtual bool matches( std::string const& str ) const {
+            switch( m_wildcard ) {
+                case NoWildcard:
+                    return m_pattern == adjustCase( str );
+                case WildcardAtStart:
+                    return endsWith( adjustCase( str ), m_pattern );
+                case WildcardAtEnd:
+                    return startsWith( adjustCase( str ), m_pattern );
+                case WildcardAtBothEnds:
+                    return contains( adjustCase( str ), m_pattern );
+            }
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunreachable-code"
+#endif
+            throw std::logic_error( "Unknown enum" );
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+        }
+    private:
+        std::string adjustCase( std::string const& str ) const {
+            return m_caseSensitivity == CaseInsensitive ? toLower( str ) : str;
+        }
+        CaseSensitivity m_caseSensitivity;
+        WildcardPosition m_wildcard;
+        std::string m_pattern;
+    };
+}
+
 #include <string>
 #include <vector>
 
@@ -2849,50 +2914,18 @@ namespace Catch {
             virtual bool matches( TestCaseInfo const& testCase ) const = 0;
         };
         class NamePattern : public Pattern {
-            enum WildcardPosition {
-                NoWildcard = 0,
-                WildcardAtStart = 1,
-                WildcardAtEnd = 2,
-                WildcardAtBothEnds = WildcardAtStart | WildcardAtEnd
-            };
-
         public:
-            NamePattern( std::string const& name ) : m_name( toLower( name ) ), m_wildcard( NoWildcard ) {
-                if( startsWith( m_name, "*" ) ) {
-                    m_name = m_name.substr( 1 );
-                    m_wildcard = WildcardAtStart;
-                }
-                if( endsWith( m_name, "*" ) ) {
-                    m_name = m_name.substr( 0, m_name.size()-1 );
-                    m_wildcard = static_cast<WildcardPosition>( m_wildcard | WildcardAtEnd );
-                }
-            }
+            NamePattern( std::string const& name )
+            : m_wildcardPattern( toLower( name ), WildcardPattern::CaseInsensitive )
+            {}
             virtual ~NamePattern();
             virtual bool matches( TestCaseInfo const& testCase ) const {
-                switch( m_wildcard ) {
-                    case NoWildcard:
-                        return m_name == toLower( testCase.name );
-                    case WildcardAtStart:
-                        return endsWith( toLower( testCase.name ), m_name );
-                    case WildcardAtEnd:
-                        return startsWith( toLower( testCase.name ), m_name );
-                    case WildcardAtBothEnds:
-                        return contains( toLower( testCase.name ), m_name );
-                }
-
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunreachable-code"
-#endif
-                throw std::logic_error( "Unknown enum" );
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+                return m_wildcardPattern.matches( toLower( testCase.name ) );
             }
         private:
-            std::string m_name;
-            WildcardPosition m_wildcard;
+            WildcardPattern m_wildcardPattern;
         };
+
         class TagPattern : public Pattern {
         public:
             TagPattern( std::string const& tag ) : m_tag( toLower( tag ) ) {}
@@ -2903,6 +2936,7 @@ namespace Catch {
         private:
             std::string m_tag;
         };
+
         class ExcludedPattern : public Pattern {
         public:
             ExcludedPattern( Ptr<Pattern> const& underlyingPattern ) : m_underlyingPattern( underlyingPattern ) {}
@@ -6827,7 +6861,7 @@ namespace Catch {
         return os;
     }
 
-    Version libraryVersion( 1, 2, 1, "develop", 6 );
+    Version libraryVersion( 1, 2, 1, "develop", 7 );
 
 }
 
@@ -7504,7 +7538,8 @@ namespace Catch {
         if( expectedMessage != "" ) {
 
             std::string actualMessage = Catch::translateActiveException();
-            if( expectedMessage != actualMessage ) {
+            WildcardPattern pattern( expectedMessage, WildcardPattern::CaseInsensitive );
+            if( !pattern.matches( actualMessage ) ) {
                 data.resultType = ResultWas::ExpressionFailed;
                 data.reconstructedExpression = actualMessage;
             }
@@ -9299,6 +9334,7 @@ namespace Catch {
     FreeFunctionTestCase::~FreeFunctionTestCase() {}
     IGeneratorInfo::~IGeneratorInfo() {}
     IGeneratorsForTest::~IGeneratorsForTest() {}
+    WildcardPattern::~WildcardPattern() {}
     TestSpec::Pattern::~Pattern() {}
     TestSpec::NamePattern::~NamePattern() {}
     TestSpec::TagPattern::~TagPattern() {}

--- a/single_include/catch.hpp
+++ b/single_include/catch.hpp
@@ -1,6 +1,6 @@
 /*
- *  Catch v1.2.1-develop.9
- *  Generated: 2015-07-23 23:06:03.575257
+ *  Catch v1.2.1-develop.10
+ *  Generated: 2015-07-24 08:13:33.830879
  *  ----------------------------------------------------------
  *  This file has been merged from multiple headers. Please don't edit it directly
  *  Copyright (c) 2012 Two Blue Cubes Ltd. All rights reserved.
@@ -6942,7 +6942,7 @@ namespace Catch {
         return os;
     }
 
-    Version libraryVersion( 1, 2, 1, "develop", 9 );
+    Version libraryVersion( 1, 2, 1, "develop", 10 );
 
 }
 

--- a/single_include/catch.hpp
+++ b/single_include/catch.hpp
@@ -1,6 +1,6 @@
 /*
- *  Catch v1.2.1-develop.2
- *  Generated: 2015-07-02 23:02:49.715552
+ *  Catch v1.2.1-develop.3
+ *  Generated: 2015-07-03 18:29:49.753953
  *  ----------------------------------------------------------
  *  This file has been merged from multiple headers. Please don't edit it directly
  *  Copyright (c) 2012 Two Blue Cubes Ltd. All rights reserved.
@@ -5213,7 +5213,7 @@ namespace Catch {
         virtual ~RunContext() {
             m_reporter->testRunEnded( TestRunStats( m_runInfo, m_totals, aborting() ) );
             m_context.setRunner( m_prevRunner );
-            m_context.setConfig( CATCH_NULL );
+            m_context.setConfig( Ptr<IConfig const>() );
             m_context.setResultCapture( m_prevResultCapture );
             m_context.setConfig( m_prevConfig );
         }
@@ -5618,7 +5618,7 @@ namespace Catch {
             std::set<std::string> tags = test.tags;
 
             std::string filename = test.lineInfo.file;
-            std::string::size_type lastSlash = filename.find_last_of( "\//" );
+            std::string::size_type lastSlash = filename.find_last_of( "\\/" );
             if( lastSlash != std::string::npos )
                 filename = filename.substr( lastSlash+1 );
 
@@ -6821,7 +6821,7 @@ namespace Catch {
         return os;
     }
 
-    Version libraryVersion( 1, 2, 1, "develop", 2 );
+    Version libraryVersion( 1, 2, 1, "develop", 3 );
 
 }
 

--- a/single_include/catch.hpp
+++ b/single_include/catch.hpp
@@ -1,6 +1,6 @@
 /*
- *  Catch v1.2.1-develop.3
- *  Generated: 2015-07-03 18:29:49.753953
+ *  Catch v1.2.1-develop.4
+ *  Generated: 2015-07-06 06:21:18.816844
  *  ----------------------------------------------------------
  *  This file has been merged from multiple headers. Please don't edit it directly
  *  Copyright (c) 2012 Two Blue Cubes Ltd. All rights reserved.
@@ -6333,12 +6333,13 @@ namespace {
         {
             CONSOLE_SCREEN_BUFFER_INFO csbiInfo;
             GetConsoleScreenBufferInfo( stdoutHandle, &csbiInfo );
-            originalAttributes = csbiInfo.wAttributes;
+            originalForegroundAttributes = csbiInfo.wAttributes & ~( BACKGROUND_GREEN | BACKGROUND_RED | BACKGROUND_BLUE | BACKGROUND_INTENSITY );
+            originalBackgroundAttributes = csbiInfo.wAttributes & ~( FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_INTENSITY );
         }
 
         virtual void use( Colour::Code _colourCode ) {
             switch( _colourCode ) {
-                case Colour::None:      return setTextAttribute( originalAttributes );
+                case Colour::None:      return setTextAttribute( originalForegroundAttributes );
                 case Colour::White:     return setTextAttribute( FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE );
                 case Colour::Red:       return setTextAttribute( FOREGROUND_RED );
                 case Colour::Green:     return setTextAttribute( FOREGROUND_GREEN );
@@ -6358,10 +6359,11 @@ namespace {
 
     private:
         void setTextAttribute( WORD _textAttribute ) {
-            SetConsoleTextAttribute( stdoutHandle, _textAttribute );
+            SetConsoleTextAttribute( stdoutHandle, _textAttribute | originalBackgroundAttributes );
         }
         HANDLE stdoutHandle;
-        WORD originalAttributes;
+        WORD originalForegroundAttributes;
+        WORD originalBackgroundAttributes;
     };
 
     IColourImpl* platformColourInstance() {
@@ -6821,7 +6823,7 @@ namespace Catch {
         return os;
     }
 
-    Version libraryVersion( 1, 2, 1, "develop", 3 );
+    Version libraryVersion( 1, 2, 1, "develop", 4 );
 
 }
 

--- a/single_include/catch.hpp
+++ b/single_include/catch.hpp
@@ -1,6 +1,6 @@
 /*
- *  Catch v1.2.1-develop.4
- *  Generated: 2015-07-06 06:21:18.816844
+ *  Catch v1.2.1-develop.5
+ *  Generated: 2015-07-07 08:24:50.226161
  *  ----------------------------------------------------------
  *  This file has been merged from multiple headers. Please don't edit it directly
  *  Copyright (c) 2012 Two Blue Cubes Ltd. All rights reserved.
@@ -4279,6 +4279,10 @@ namespace Catch {
             .describe( "load test names to run from a file" )
             .bind( &loadTestNamesFromFile, "filename" );
 
+        cli["-#"]["--filenames-as-tags"]
+            .describe( "adds a tag for the filename" )
+            .bind( &ConfigData::filenamesAsTags );
+
         // Less common commands which don't have a short form
         cli["--list-test-names-only"]
             .describe( "list all/matching test cases names only" )
@@ -4299,10 +4303,6 @@ namespace Catch {
         cli["--force-colour"]
             .describe( "force colourised output" )
             .bind( &ConfigData::forceColour );
-
-        cli["--filenames-as-tags"]
-            .describe( "adds a tag for the filename" )
-            .bind( &ConfigData::filenamesAsTags );
 
         return cli;
     }
@@ -5626,7 +5626,7 @@ namespace Catch {
             if( lastDot != std::string::npos )
                 filename = filename.substr( 0, lastDot );
 
-            tags.insert( "@" + filename );
+            tags.insert( "#" + filename );
             setTags( test, tags );
         }
     }
@@ -6823,7 +6823,7 @@ namespace Catch {
         return os;
     }
 
-    Version libraryVersion( 1, 2, 1, "develop", 4 );
+    Version libraryVersion( 1, 2, 1, "develop", 5 );
 
 }
 

--- a/single_include/catch.hpp
+++ b/single_include/catch.hpp
@@ -1,6 +1,6 @@
 /*
- *  Catch v1.2.0
- *  Generated: 2015-06-29 08:12:52.943445
+ *  Catch v1.2.1
+ *  Generated: 2015-06-30 18:23:27.961086
  *  ----------------------------------------------------------
  *  This file has been merged from multiple headers. Please don't edit it directly
  *  Copyright (c) 2012 Two Blue Cubes Ltd. All rights reserved.
@@ -87,19 +87,23 @@
 
 // CATCH_CONFIG_CPP11_OR_GREATER : Is C++11 supported?
 
-// CATCH_CONFIG_SFINAE : is basic (C++03) SFINAE supported?
 // CATCH_CONFIG_VARIADIC_MACROS : are variadic macros supported?
 
-// A lot of this code is based on Boost (1.53)
+// In general each macro has a _NO_<feature name> form
+// (e.g. CATCH_CONFIG_CPP11_NO_NULLPTR) which disables the feature.
+// Many features, at point of detection, define an _INTERNAL_ macro, so they
+// can be combined, en-mass, with the _NO_ forms later.
+
+// All the C++11 features can be disabled with CATCH_CONFIG_NO_CPP11
 
 #ifdef __clang__
 
 #  if __has_feature(cxx_nullptr)
-#    define CATCH_CONFIG_CPP11_NULLPTR
+#    define CATCH_INTERNAL_CONFIG_CPP11_NULLPTR
 #  endif
 
 #  if __has_feature(cxx_noexcept)
-#    define CATCH_CONFIG_CPP11_NOEXCEPT
+#    define CATCH_INTERNAL_CONFIG_CPP11_NOEXCEPT
 #  endif
 
 #endif // __clang__
@@ -108,19 +112,11 @@
 // Borland
 #ifdef __BORLANDC__
 
-#if (__BORLANDC__ > 0x582 )
-//#define CATCH_CONFIG_SFINAE // Not confirmed
-#endif
-
 #endif // __BORLANDC__
 
 ////////////////////////////////////////////////////////////////////////////////
 // EDG
 #ifdef __EDG_VERSION__
-
-#if (__EDG_VERSION__ > 238 )
-//#define CATCH_CONFIG_SFINAE // Not confirmed
-#endif
 
 #endif // __EDG_VERSION__
 
@@ -128,31 +124,14 @@
 // Digital Mars
 #ifdef __DMC__
 
-#if (__DMC__ > 0x840 )
-//#define CATCH_CONFIG_SFINAE // Not confirmed
-#endif
-
 #endif // __DMC__
 
 ////////////////////////////////////////////////////////////////////////////////
 // GCC
 #ifdef __GNUC__
 
-#if __GNUC__ < 3
-
-#if (__GNUC_MINOR__ >= 96 )
-//#define CATCH_CONFIG_SFINAE
-#endif
-
-#elif __GNUC__ >= 3
-
-// #define CATCH_CONFIG_SFINAE // Taking this out completely for now
-
-#endif // __GNUC__ < 3
-
 #if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6 && defined(__GXX_EXPERIMENTAL_CXX0X__) )
-
-#define CATCH_CONFIG_CPP11_NULLPTR
+#   define CATCH_INTERNAL_CONFIG_CPP11_NULLPTR
 #endif
 
 #endif // __GNUC__
@@ -161,17 +140,13 @@
 // Visual C++
 #ifdef _MSC_VER
 
-#if (_MSC_VER >= 1310 ) // (VC++ 7.0+)
-//#define CATCH_CONFIG_SFINAE // Not confirmed
-#endif
-
 #if (_MSC_VER >= 1600)
-#define CATCH_CONFIG_CPP11_NULLPTR
+#   define CATCH_INTERNAL_CONFIG_CPP11_NULLPTR
 #endif
 
 #if (_MSC_VER >= 1900 ) // (VC++ 13 (VS2015))
-#define CATCH_CONFIG_CPP11_NOEXCEPT
-#define CATCH_CONFIG_CPP11_GENERATED_METHODS
+#define CATCH_INTERNAL_CONFIG_CPP11_NOEXCEPT
+#define CATCH_INTERNAL_CONFIG_CPP11_GENERATED_METHODS
 #endif
 
 #endif // _MSC_VER
@@ -182,9 +157,7 @@
     ( defined __GNUC__ && __GNUC__ >= 3 ) || \
     ( !defined __cplusplus && __STDC_VERSION__ >= 199901L || __cplusplus >= 201103L )
 
-#ifndef CATCH_CONFIG_NO_VARIADIC_MACROS
-#define CATCH_CONFIG_VARIADIC_MACROS
-#endif
+#define CATCH_INTERNAL_CONFIG_VARIADIC_MACROS
 
 #endif
 
@@ -196,35 +169,51 @@
 
 #  define CATCH_CPP11_OR_GREATER
 
-#  ifndef CATCH_CONFIG_CPP11_NULLPTR
-#    define CATCH_CONFIG_CPP11_NULLPTR
+#  if !defined(CATCH_INTERNAL_CONFIG_CPP11_NULLPTR)
+#    define CATCH_INTERNAL_CONFIG_CPP11_NULLPTR
 #  endif
 
-#  ifndef CATCH_CONFIG_CPP11_NOEXCEPT
-#    define CATCH_CONFIG_CPP11_NOEXCEPT
+#  ifndef CATCH_INTERNAL_CONFIG_CPP11_NOEXCEPT
+#    define CATCH_INTERNAL_CONFIG_CPP11_NOEXCEPT
 #  endif
 
-#  ifndef CATCH_CONFIG_CPP11_GENERATED_METHODS
-#    define CATCH_CONFIG_CPP11_GENERATED_METHODS
+#  ifndef CATCH_INTERNAL_CONFIG_CPP11_GENERATED_METHODS
+#    define CATCH_INTERNAL_CONFIG_CPP11_GENERATED_METHODS
 #  endif
 
-#  ifndef CATCH_CONFIG_CPP11_IS_ENUM
-#    define CATCH_CONFIG_CPP11_IS_ENUM
+#  ifndef CATCH_INTERNAL_CONFIG_CPP11_IS_ENUM
+#    define CATCH_INTERNAL_CONFIG_CPP11_IS_ENUM
 #  endif
 
-#  ifndef CATCH_CONFIG_CPP11_TUPLE
-#    define CATCH_CONFIG_CPP11_TUPLE
+#  ifndef CATCH_INTERNAL_CONFIG_CPP11_TUPLE
+#    define CATCH_INTERNAL_CONFIG_CPP11_TUPLE
 #  endif
 
-#  ifndef CATCH_CONFIG_SFINAE
-//#    define CATCH_CONFIG_SFINAE // Don't use, for now
-#  endif
-
-#  ifndef CATCH_CONFIG_VARIADIC_MACROS
-#    define CATCH_CONFIG_VARIADIC_MACROS
+#  ifndef CATCH_INTERNAL_CONFIG_VARIADIC_MACROS
+#    define CATCH_INTERNAL_CONFIG_VARIADIC_MACROS
 #  endif
 
 #endif // __cplusplus >= 201103L
+
+// Now set the actual defines based on the above + anything the user has configured
+#if defined(CATCH_INTERNAL_CONFIG_CPP11_NULLPTR) && !defined(CATCH_CONFIG_CPP11_NO_NULLPTR) && !defined(CATCH_CONFIG_CPP11_NULLPTR) && !defined(CATCH_CONFIG_NO_CPP11)
+#   define CATCH_CONFIG_CPP11_NULLPTR
+#endif
+#if defined(CATCH_INTERNAL_CONFIG_CPP11_NOEXCEPT) && !defined(CATCH_CONFIG_CPP11_NO_NOEXCEPT) && !defined(CATCH_CONFIG_CPP11_NOEXCEPT) && !defined(CATCH_CONFIG_NO_CPP11)
+#   define CATCH_CONFIG_CPP11_NOEXCEPT
+#endif
+#if defined(CATCH_INTERNAL_CONFIG_CPP11_GENERATED_METHODS) && !defined(CATCH_CONFIG_CPP11_NO_GENERATED_METHODS) && !defined(CATCH_CONFIG_CPP11_GENERATED_METHODS) && !defined(CATCH_CONFIG_NO_CPP11)
+#   define CATCH_CONFIG_CPP11_GENERATED_METHODS
+#endif
+#if defined(CATCH_INTERNAL_CONFIG_CPP11_IS_ENUM) && !defined(CATCH_CONFIG_CPP11_NO_IS_ENUM) && !defined(CATCH_CONFIG_CPP11_IS_ENUM) && !defined(CATCH_CONFIG_NO_CPP11)
+#   define CATCH_CONFIG_CPP11_IS_ENUM
+#endif
+#if defined(CATCH_INTERNAL_CONFIG_CPP11_TUPLE) && !defined(CATCH_CONFIG_CPP11_NO_TUPLE) && !defined(CATCH_CONFIG_CPP11_TUPLE) && !defined(CATCH_CONFIG_NO_CPP11)
+#   define CATCH_CONFIG_CPP11_TUPLE
+#endif
+#if defined(CATCH_INTERNAL_CONFIG_VARIADIC_MACROS) && !defined(CATCH_CONFIG_NO_VARIADIC_MACROS) && !defined(CATCH_CONFIG_VARIADIC_MACROS)
+#define CATCH_CONFIG_VARIADIC_MACROS
+#endif
 
 // noexcept support:
 #if defined(CATCH_CONFIG_CPP11_NOEXCEPT) && !defined(CATCH_NOEXCEPT)
@@ -1022,40 +1011,6 @@ namespace Internal {
 // #included from: catch_tostring.h
 #define TWOBLUECUBES_CATCH_TOSTRING_H_INCLUDED
 
-// #included from: catch_sfinae.hpp
-#define TWOBLUECUBES_CATCH_SFINAE_HPP_INCLUDED
-
-// Try to detect if the current compiler supports SFINAE
-
-namespace Catch {
-
-    struct TrueType {
-        static const bool value = true;
-        typedef void Enable;
-        char sizer[1];
-    };
-    struct FalseType {
-        static const bool value = false;
-        typedef void Disable;
-        char sizer[2];
-    };
-
-#ifdef CATCH_CONFIG_SFINAE
-
-    template<bool> struct NotABooleanExpression;
-
-    template<bool c> struct If : NotABooleanExpression<c> {};
-    template<> struct If<true> : TrueType {};
-    template<> struct If<false> : FalseType {};
-
-    template<int size> struct SizedIf;
-    template<> struct SizedIf<sizeof(TrueType)> : TrueType {};
-    template<> struct SizedIf<sizeof(FalseType)> : FalseType {};
-
-#endif // CATCH_CONFIG_SFINAE
-
-} // end namespace Catch
-
 #include <sstream>
 #include <iomanip>
 #include <limits>
@@ -1154,31 +1109,12 @@ namespace Detail {
 
     extern std::string unprintableString;
 
-// SFINAE is currently disabled by default for all compilers.
-// If the non SFINAE version of IsStreamInsertable is ambiguous for you
-// and your compiler supports SFINAE, try #defining CATCH_CONFIG_SFINAE
-#ifdef CATCH_CONFIG_SFINAE
-
-    template<typename T>
-    class IsStreamInsertableHelper {
-        template<int N> struct TrueIfSizeable : TrueType {};
-
-        template<typename T2>
-        static TrueIfSizeable<sizeof((*(std::ostream*)0) << *((T2 const*)0))> dummy(T2*);
-        static FalseType dummy(...);
-
-    public:
-        typedef SizedIf<sizeof(dummy((T*)0))> type;
-    };
-
-    template<typename T>
-    struct IsStreamInsertable : IsStreamInsertableHelper<T>::type {};
-
-#else
-
     struct BorgType {
         template<typename T> BorgType( T const& );
     };
+
+    struct TrueType { char sizer[1]; };
+    struct FalseType { char sizer[2]; };
 
     TrueType& testStreamable( std::ostream& );
     FalseType testStreamable( FalseType );
@@ -1191,8 +1127,6 @@ namespace Detail {
         static T  const&t;
         enum { value = sizeof( testStreamable(s << t) ) == sizeof( TrueType ) };
     };
-
-#endif
 
 #if defined(CATCH_CONFIG_CPP11_IS_ENUM)
     template<typename T,
@@ -5016,32 +4950,15 @@ namespace SectionTracking {
 
         RunState runState() const { return m_runState; }
 
-        TrackedSection* findChild( std::string const& childName ) {
-            TrackedSections::iterator it = m_children.find( childName );
-            return it != m_children.end()
-                ? &it->second
-                : NULL;
-        }
-        TrackedSection* acquireChild( std::string const& childName ) {
-            if( TrackedSection* child = findChild( childName ) )
-                return child;
-            m_children.insert( std::make_pair( childName, TrackedSection( childName, this ) ) );
-            return findChild( childName );
-        }
+        TrackedSection* findChild( std::string const& childName );
+        TrackedSection* acquireChild( std::string const& childName );
+
         void enter() {
             if( m_runState == NotStarted )
                 m_runState = Executing;
         }
-        void leave() {
-            for( TrackedSections::const_iterator it = m_children.begin(), itEnd = m_children.end();
-                    it != itEnd;
-                    ++it )
-                if( it->second.runState() != Completed ) {
-                    m_runState = ExecutingChildren;
-                    return;
-                }
-            m_runState = Completed;
-        }
+        void leave();
+
         TrackedSection* getParent() {
             return m_parent;
         }
@@ -5054,8 +4971,30 @@ namespace SectionTracking {
         RunState m_runState;
         TrackedSections m_children;
         TrackedSection* m_parent;
-
     };
+
+    inline TrackedSection* TrackedSection::findChild( std::string const& childName ) {
+        TrackedSections::iterator it = m_children.find( childName );
+        return it != m_children.end()
+            ? &it->second
+            : NULL;
+    }
+    inline TrackedSection* TrackedSection::acquireChild( std::string const& childName ) {
+        if( TrackedSection* child = findChild( childName ) )
+            return child;
+        m_children.insert( std::make_pair( childName, TrackedSection( childName, this ) ) );
+        return findChild( childName );
+    }
+    inline void TrackedSection::leave() {
+        for( TrackedSections::const_iterator it = m_children.begin(), itEnd = m_children.end();
+                it != itEnd;
+                ++it )
+            if( it->second.runState() != Completed ) {
+                m_runState = ExecutingChildren;
+                return;
+            }
+        m_runState = Completed;
+    }
 
     class TestCaseTracker {
     public:
@@ -6828,7 +6767,7 @@ namespace Catch {
         return os;
     }
 
-    Version libraryVersion( 1, 2, 0, "", 0 );
+    Version libraryVersion( 1, 2, 1, "", 0 );
 
 }
 

--- a/single_include/catch.hpp
+++ b/single_include/catch.hpp
@@ -1,6 +1,6 @@
 /*
- *  Catch v1.2.1-develop.1
- *  Generated: 2015-07-02 08:21:11.983471
+ *  Catch v1.2.1-develop.2
+ *  Generated: 2015-07-02 23:02:49.715552
  *  ----------------------------------------------------------
  *  This file has been merged from multiple headers. Please don't edit it directly
  *  Copyright (c) 2012 Two Blue Cubes Ltd. All rights reserved.
@@ -233,6 +233,8 @@
 
 namespace Catch {
 
+    struct IConfig;
+
     class NonCopyable {
 #ifdef CATCH_CONFIG_CPP11_GENERATED_METHODS
         NonCopyable( NonCopyable const& )              = delete;
@@ -318,6 +320,9 @@ namespace Catch {
     inline bool alwaysFalse() { return false; }
 
     void throwLogicError( std::string const& message, SourceLineInfo const& locationInfo );
+
+    void seedRng( IConfig const& config );
+    unsigned int rngSeed();
 
     // Use this in variadic streaming macros to allow
     //    >> +StreamEndStop
@@ -5388,6 +5393,8 @@ namespace Catch {
                 m_lastAssertionInfo = AssertionInfo( "TEST_CASE", testCaseInfo.lineInfo, "", ResultDisposition::Normal );
                 TestCaseTracker::Guard guard( *m_testCaseTracker );
 
+                seedRng( *m_config );
+
                 Timer timer;
                 timer.start();
                 if( m_reporter->getPreferences().shouldRedirectStdOut ) {
@@ -5697,7 +5704,7 @@ namespace Catch {
                 if( m_configData.filenamesAsTags )
                     applyFilenamesAsTags();
 
-                std::srand( m_configData.rngSeed );
+                seedRng( *m_config );
 
                 Runner runner( m_config );
 
@@ -5822,6 +5829,8 @@ namespace Catch {
                     break;
                 case RunTests::InRandomOrder:
                 {
+                    seedRng( config );
+
                     RandomNumberGenerator rng;
                     std::random_shuffle( matchingTestCases.begin(), matchingTestCases.end(), rng );
                 }
@@ -6812,7 +6821,7 @@ namespace Catch {
         return os;
     }
 
-    Version libraryVersion( 1, 2, 1, "develop", 1 );
+    Version libraryVersion( 1, 2, 1, "develop", 2 );
 
 }
 
@@ -7102,6 +7111,14 @@ namespace Catch {
     }
     bool SourceLineInfo::operator < ( SourceLineInfo const& other ) const {
         return line < other.line || ( line == other.line  && file < other.file );
+    }
+
+    void seedRng( IConfig const& config ) {
+        if( config.rngSeed() != 0 )
+            std::srand( config.rngSeed() );
+    }
+    unsigned int rngSeed() {
+        return getCurrentContext().getConfig()->rngSeed();
     }
 
     std::ostream& operator << ( std::ostream& os, SourceLineInfo const& info ) {


### PR DESCRIPTION
This change allows Catch to work (or at least compile) on GCC 5.2 when it is not running in C++11 mode (no standard specified on the command line).  I am using i686-w64-mingw32 gcc 5.2.0 built by the MSYS2 project.

My understanding is that nullptr was introduced in C++11, so it seems like we should check to see whether we are running C++11 mode and only attempt to use nullptr if that is the case.  Every GCC since 4.7 has a __cplusplus macro we can check to see what version of the C++ standard is being used.  This change preserves the logic that was used for GCC 4, but for GCC versions greater than 4, it checks the __cplusplus macro to see if nullptr is supported.

I assume there isn't much harm in false negative with this macro.  Since my change will strictly decrease the set of compilers where Catch attempts to use nullptr, I think it should be pretty safe.
