### PR TITLE
Fix for nullptr in GCC 5.2

### DIFF
--- a/include/internal/catch_compiler_capabilities.h
+++ b/include/internal/catch_compiler_capabilities.h
@@ -67,7 +67,7 @@
 // GCC
 #ifdef __GNUC__
 
-#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6 && defined(__GXX_EXPERIMENTAL_CXX0X__) )
+#if (__GNUC__ > 4 && __cplusplus >= 201103L) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6 && defined(__GXX_EXPERIMENTAL_CXX0X__) )
 #   define CATCH_INTERNAL_CONFIG_CPP11_NULLPTR
 #endif
 


### PR DESCRIPTION
This change allows Catch to work (or at least compile) on GCC 5.2 when it is not running in C++11 mode (no standard specified on the command line). I am using i686-w64-mingw32 gcc 5.2.0 built by the MSYS2 project.

My understanding is that nullptr was introduced in C++11, so it seems like we should check to see whether we are running C++11 mode and only attempt to use nullptr if that is the case. Every GCC since 4.7 has a __cplusplus macro we can check to see what version of the C++ standard is being used. This change preserves the logic that was used for GCC 4, but for GCC versions greater than 4, it checks the __cplusplus macro to see if nullptr is supported.

I assume there isn't much harm in false negatives with this macro. Since my change will strictly decrease the set of environments where Catch attempts to use nullptr, I think it should be pretty safe.