### PR TITLE
Add missing comma when in captured expression for matchers

### DIFF
--- a/include/internal/catch_capture.hpp
+++ b/include/internal/catch_capture.hpp
@@ -129,7 +129,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 #define INTERNAL_CHECK_THAT( arg, matcher, resultDisposition, macroName ) \
     do { \
-        Catch::ResultBuilder __catchResult( macroName, CATCH_INTERNAL_LINEINFO, #arg " " #matcher, resultDisposition ); \
+        Catch::ResultBuilder __catchResult( macroName, CATCH_INTERNAL_LINEINFO, #arg ", " #matcher, resultDisposition ); \
         try { \
             std::string matcherAsString = ::Catch::Matchers::matcher.toString(); \
             __catchResult \


### PR DESCRIPTION
Such that

```
  CHECK_THAT( hex_encode(outbuf) Equals("B5D4045C") )
```

becomes

```
  CHECK_THAT( hex_encode(outbuf), Equals("B5D4045C") )
```