### PR TITLE
Fixes for Coverity static analysis issues

### DIFF
--- a/include/internal/catch_assertionresult.h
+++ b/include/internal/catch_assertionresult.h
@@ -15,7 +15,7 @@ namespace Catch {
 
     struct AssertionInfo
     {
-        AssertionInfo() {}
+        AssertionInfo() : resultDisposition( ResultDisposition::Normal ) {}
         AssertionInfo(  std::string const& _macroName,
                         SourceLineInfo const& _lineInfo,
                         std::string const& _capturedExpression,

--- a/include/internal/catch_test_case_registry_impl.hpp
+++ b/include/internal/catch_test_case_registry_impl.hpp
@@ -22,7 +22,7 @@
 namespace Catch {
 
     struct LexSort {
-        bool operator() (TestCase i,TestCase j) const { return (i<j);}
+        bool operator() ( TestCase const& i, TestCase const& j) const { return ( i < j ); }
     };
     struct RandomNumberGenerator {
         int operator()( int n ) const { return std::rand() % n; }

--- a/include/internal/catch_test_spec_parser.hpp
+++ b/include/internal/catch_test_spec_parser.hpp
@@ -29,7 +29,12 @@ namespace Catch {
         ITagAliasRegistry const* m_tagAliases;
 
     public:
-        TestSpecParser( ITagAliasRegistry const& tagAliases ) : m_tagAliases( &tagAliases ) {}
+        TestSpecParser( ITagAliasRegistry const& tagAliases )
+        :   m_tagAliases( &tagAliases ),
+            m_mode( None ),
+            m_exclusion( false ),
+            m_start( std::string::npos ),
+            m_pos( 0 ) {}
 
         TestSpecParser& parse( std::string const& arg ) {
             m_mode = None;

--- a/include/reporters/catch_reporter_junit.hpp
+++ b/include/reporters/catch_reporter_junit.hpp
@@ -22,6 +22,7 @@ namespace Catch {
     public:
         JunitReporter( ReporterConfig const& _config )
         :   CumulativeReporterBase( _config ),
+            unexpectedExceptions( 0 ),
             xml( _config.stream() )
         {
             m_reporterPrefs.shouldRedirectStdOut = true;


### PR DESCRIPTION
Running a Coverity scan on this project yielded two possible issues which I have resolved:

- Big parameters passed by value
- Uninitialized scalar fields

All changes but one were made to "internals".  The one change to an external (`Catch::JunitReporter`) did not affect the it's interface. Thus only require a "patch" (third version number) number update to the version number according to [Semantic Versioning 2.0](http://semver.org).

This pull request replaces #488 which was done on the wrong branch.

Many thanks to @Tarnasa for helping out with this.