### PR TITLE
Fix parentheses warning on expression evaluation when using ccache

### DIFF
--- a/include/internal/catch_capture.hpp
+++ b/include/internal/catch_capture.hpp
@@ -33,7 +33,7 @@
     do { \
         Catch::ResultBuilder __catchResult( macroName, CATCH_INTERNAL_LINEINFO, #expr, resultDisposition ); \
         try { \
-            ( __catchResult <= expr ).endExpression(); \
+            ( __catchResult <= (expr) ).endExpression(); \
         } \
         catch( ... ) { \
             __catchResult.useActiveException( Catch::ResultDisposition::Normal ); \


### PR DESCRIPTION
Hi !

I found an issue using ccache.

To reproduce it, just add ccache & gcc options in your CMakeList:
```cmake
set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -rdynamic -Wall -Werror")

set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
```

Then try to build a simple test:
```c++
SCENARIO("test")
{
    GIVEN("givenTest")
    {
        int i = 1;
        WHEN("whenTest")
        {
            REQUIRE(i == 1);
        }
    }
}
```

Y'oull get the following output:
```
error: suggest parentheses around comparison in operand of ‘==’ [-Werror=parentheses]
REQUIRE(i == 1);
```

Fix it by adding parenthesis around `expr` in `INTERNAL_CATCH_TEST`