### PR TITLE
Allow overriding std::exception translation

### DIFF
--- a/include/internal/catch_exception_translator_registry.hpp
+++ b/include/internal/catch_exception_translator_registry.hpp
@@ -45,7 +45,17 @@ namespace Catch {
                 throw;
             }
             catch( std::exception& ex ) {
-                return ex.what();
+                try {
+                    try {
+                        throw;
+                    }
+                    catch(...) {
+                        return tryTranslators( m_translators.begin() );
+                    }
+                }
+                catch( std::exception& ex ) {
+                    return ex.what();
+                }
             }
             catch( std::string& msg ) {
                 return msg;
@@ -54,13 +64,18 @@ namespace Catch {
                 return msg;
             }
             catch(...) {
-                return tryTranslators( m_translators.begin() );
+                try {
+                    return tryTranslators( m_translators.begin() );
+                }
+                catch(...) {
+                    return "Unknown exception";
+                }
             }
         }
 
         std::string tryTranslators( std::vector<const IExceptionTranslator*>::const_iterator it ) const {
             if( it == m_translators.end() )
-                return "Unknown exception";
+                throw;
 
             try {
                 return (*it)->translate();


### PR DESCRIPTION
CATCH_TRANSLATE_EXCEPTION allows to only translate exceptions which are
not inherited from std::exception (as well as std::string and char*).
There're exception classes though which inherit from std::exception but
don't provide any meaningful info as what() result, Poco::Exception being
one of those. In this case, adding translator like
```
    CATCH_TRANSLATE_EXCEPTION(Poco::Exception const& e)
    {
        return e.displayText();
    }
```
might help, but unfortunately it's not functioning as desired.

This commit makes it possible to provide translation overrides for
std::exception-derived classes.