### PR TITLE
Add --no-colour command-line option

### DIFF
--- a/include/internal/catch_commandline.hpp
+++ b/include/internal/catch_commandline.hpp
@@ -74,6 +74,12 @@ namespace Catch {
                 addTestOrTags( config, "\"" + line + "\"," );
         }
     }
+    inline void setForceColourAlways( ConfigData& config ) {
+        config.forceColour = ForceColour::Always;
+    }
+    inline void setForceColourNever( ConfigData& config ) {
+        config.forceColour = ForceColour::Never;
+    }
 
     inline Clara::CommandLine<ConfigData> makeCommandLineParser() {
 
@@ -177,8 +183,12 @@ namespace Catch {
 
         cli["--force-colour"]
             .describe( "force colourised output" )
-            .bind( &ConfigData::forceColour );
+            .bind( &setForceColourAlways );
         
+        cli["--force-no-colour"]
+            .describe( "force non-colourised output" )
+            .bind( &setForceColourNever );
+
         return cli;
     }
 

--- a/include/internal/catch_commandline.hpp
+++ b/include/internal/catch_commandline.hpp
@@ -185,7 +185,7 @@ namespace Catch {
             .describe( "force colourised output" )
             .bind( &setForceColourAlways );
         
-        cli["--force-no-colour"]
+        cli["--no-colour"]
             .describe( "force non-colourised output" )
             .bind( &setForceColourNever );
 

--- a/include/internal/catch_config.hpp
+++ b/include/internal/catch_config.hpp
@@ -37,14 +37,14 @@ namespace Catch {
             noThrow( false ),
             showHelp( false ),
             showInvisibles( false ),
-            forceColour( false ),
             filenamesAsTags( false ),
             abortAfter( -1 ),
             rngSeed( 0 ),
             verbosity( Verbosity::Normal ),
             warnings( WarnAbout::Nothing ),
             showDurations( ShowDurations::DefaultForReporter ),
-            runOrder( RunTests::InDeclarationOrder )
+            runOrder( RunTests::InDeclarationOrder ),
+            forceColour( ForceColour::DefaultForOutput )
         {}
 
         bool listTests;
@@ -57,7 +57,6 @@ namespace Catch {
         bool noThrow;
         bool showHelp;
         bool showInvisibles;
-        bool forceColour;
         bool filenamesAsTags;
 
         int abortAfter;
@@ -67,6 +66,7 @@ namespace Catch {
         WarnAbout::What warnings;
         ShowDurations::OrNot showDurations;
         RunTests::InWhatOrder runOrder;
+        ForceColour::OrNot forceColour;
 
         std::string outputFilename;
         std::string name;
@@ -151,7 +151,7 @@ namespace Catch {
         virtual ShowDurations::OrNot showDurations() const { return m_data.showDurations; }
         virtual RunTests::InWhatOrder runOrder() const  { return m_data.runOrder; }
         virtual unsigned int rngSeed() const    { return m_data.rngSeed; }
-        virtual bool forceColour() const { return m_data.forceColour; }
+        virtual ForceColour::OrNot forceColour() const { return m_data.forceColour; }
 
     private:
         ConfigData m_data;

--- a/include/internal/catch_console_colour_impl.hpp
+++ b/include/internal/catch_console_colour_impl.hpp
@@ -146,9 +146,17 @@ namespace {
 
     IColourImpl* platformColourInstance() {
         Ptr<IConfig const> config = getCurrentContext().getConfig();
-        return (config && config->forceColour()) || isatty(STDOUT_FILENO)
-            ? PosixColourImpl::instance()
-            : NoColourImpl::instance();
+        if (!config)
+            return NoColourImpl::instance();
+
+        switch (config->forceColour()) {
+            case ForceColour::Always: return PosixColourImpl::instance();
+            case ForceColour::Never:  return NoColourImpl::instance();
+
+            default: return isatty(STDOUT_FILENO)
+                ? PosixColourImpl::instance()
+                : NoColourImpl::instance();
+        }
     }
 
 } // end anon namespace

--- a/include/internal/catch_interfaces_config.h
+++ b/include/internal/catch_interfaces_config.h
@@ -38,6 +38,12 @@ namespace Catch {
         InRandomOrder
     }; };
 
+    struct ForceColour { enum OrNot {
+        DefaultForOutput,
+        Always,
+        Never
+    }; };
+
     class TestSpec;
 
     struct IConfig : IShared {
@@ -56,7 +62,7 @@ namespace Catch {
         virtual TestSpec const& testSpec() const = 0;
         virtual RunTests::InWhatOrder runOrder() const = 0;
         virtual unsigned int rngSeed() const = 0;
-        virtual bool forceColour() const = 0;
+        virtual ForceColour::OrNot forceColour() const = 0;
     };
 }
 

--- a/projects/SelfTest/TestMain.cpp
+++ b/projects/SelfTest/TestMain.cpp
@@ -201,14 +201,14 @@ TEST_CASE( "Process can be configured on command line", "[config][command-line]"
             REQUIRE( config.forceColour == Catch::ForceColour::Always );
         }
 
-        SECTION( "--force-no-colour", "" ) {
-            const char* argv[] = { "test", "--force-no-colour" };
+        SECTION( "--no-colour", "" ) {
+            const char* argv[] = { "test", "--no-colour" };
             CHECK_NOTHROW( parseIntoConfig( argv, config ) );
 
             REQUIRE( config.forceColour == Catch::ForceColour::Never );
         }
         
-        SECTION( "without --force-colour or --force-no-colour", "" ) {
+        SECTION( "without --force-colour or --no-colour", "" ) {
             const char* argv[] = { "test" };
             CHECK_NOTHROW( parseIntoConfig( argv, config ) );
 

--- a/projects/SelfTest/TestMain.cpp
+++ b/projects/SelfTest/TestMain.cpp
@@ -193,19 +193,26 @@ TEST_CASE( "Process can be configured on command line", "[config][command-line]"
         }
     }
 
-    SECTION( "force-colour", "") {
+    SECTION( "force-colour/force-no-color", "") {
         SECTION( "--force-colour", "" ) {
             const char* argv[] = { "test", "--force-colour" };
             CHECK_NOTHROW( parseIntoConfig( argv, config ) );
 
-            REQUIRE( config.forceColour );
+            REQUIRE( config.forceColour == Catch::ForceColour::Always );
         }
 
-        SECTION( "without --force-colour", "" ) {
+        SECTION( "--force-no-colour", "" ) {
+            const char* argv[] = { "test", "--force-no-colour" };
+            CHECK_NOTHROW( parseIntoConfig( argv, config ) );
+
+            REQUIRE( config.forceColour == Catch::ForceColour::Never );
+        }
+        
+        SECTION( "without --force-colour or --force-no-colour", "" ) {
             const char* argv[] = { "test" };
             CHECK_NOTHROW( parseIntoConfig( argv, config ) );
 
-            REQUIRE( !config.forceColour );
+            REQUIRE( config.forceColour == Catch::ForceColour::DefaultForOutput );
         }
     }
 }


### PR DESCRIPTION
Adds a --no-colour command-line option that will disable colourised output even if the output device/stream supports it.