### PR TITLE
Fix warnings with gcc 4.7 and -Werror=parentheses

### DIFF
--- a/include/internal/catch_suppress_warnings.h
+++ b/include/internal/catch_suppress_warnings.h
@@ -23,6 +23,7 @@
 #elif defined __GNUC__
 #    pragma GCC diagnostic ignored "-Wvariadic-macros"
 #    pragma GCC diagnostic ignored "-Wunused-variable"
+#    pragma GCC diagnostic ignored "-Wparentheses"
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wpadded"
 #endif


### PR DESCRIPTION
Fixes issues with GCC where errors of the form `error: suggest parentheses around comparison in operand of ‘==’ [-Werror=parentheses]`. Seems to only happen with GCC 4.7, for whatever bizarre reason.

Should address issue #496 without the nasty side effects (and reversion).

e.g. fixes errors seen in: https://travis-ci.org/mattgodbolt/seasocks/jobs/86310974 (now https://travis-ci.org/mattgodbolt/seasocks/jobs/86313317)