### PR TITLE
restrict nullptr detection to gcc 4 (closes #526)

### DIFF
--- a/include/internal/catch_compiler_capabilities.h
+++ b/include/internal/catch_compiler_capabilities.h
@@ -66,7 +66,7 @@
 // GCC
 #ifdef __GNUC__
 
-#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6 && defined(__GXX_EXPERIMENTAL_CXX0X__) )
+#if __GNUC__ == 4 && __GNUC_MINOR__ >= 6 && defined(__GXX_EXPERIMENTAL_CXX0X__)
 #   define CATCH_INTERNAL_CONFIG_CPP11_NULLPTR
 #endif
 


### PR DESCRIPTION
The old detection logic here assumed that all versions of gcc >= 5 would
provide nullptr and `std::nullptr_t`; this is only true in gcc >= 5 when
the standard is explicitly set (e.g. `std=c++11`), and other detection
logic handles that.

This change allows Catch-using programs to compile with gcc >= 5, when
using the default (C++98) standard.