### PR TITLE
Disable -Wparentheses warnings for g++ < 4.8

### DIFF
--- a/include/internal/catch_suppress_warnings.h
+++ b/include/internal/catch_suppress_warnings.h
@@ -23,6 +23,9 @@
 #elif defined __GNUC__
 #    pragma GCC diagnostic ignored "-Wvariadic-macros"
 #    pragma GCC diagnostic ignored "-Wunused-variable"
+#    if __GNUC__ == 4 && __GNUC_MINOR__ < 8
+#       pragma GCC diagnostic ignored "-Wparentheses"
+#    endif
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wpadded"
 #endif

--- a/single_include/catch.hpp
+++ b/single_include/catch.hpp
@@ -1,6 +1,6 @@
 /*
  *  Catch v1.2.1-develop.14
- *  Generated: 2015-09-27 03:27:04.922060
+ *  Generated: 2015-10-28 20:19:33.812850
  *  ----------------------------------------------------------
  *  This file has been merged from multiple headers. Please don't edit it directly
  *  Copyright (c) 2012 Two Blue Cubes Ltd. All rights reserved.
@@ -39,6 +39,9 @@
 #elif defined __GNUC__
 #    pragma GCC diagnostic ignored "-Wvariadic-macros"
 #    pragma GCC diagnostic ignored "-Wunused-variable"
+#    if __GNUC__ == 4 && __GNUC_MINOR__ < 8
+#       pragma GCC diagnostic ignored "-Wparentheses"
+#    endif
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wpadded"
 #endif


### PR DESCRIPTION
Since the changes of #247, a "warning: suggest parentheses around comparison
in operand of '=='" is generated for every use of CHECK(x == y) under -Wall.

Unfortunately the only way to get rid of the flood of such warnings seem to be
to disable it completely. At least this only has to be done for g++ <= 4.7 as
4.8 and later don't give these warnings for the use of CHECK() any more.