### PR TITLE
Get rid of unused parameter in TestEventListenerBase::assertionEnded()

### DIFF
--- a/include/reporters/catch_reporter_bases.hpp
+++ b/include/reporters/catch_reporter_bases.hpp
@@ -237,7 +237,7 @@ namespace Catch {
         {}
         
         virtual void assertionStarting( AssertionInfo const& ) CATCH_OVERRIDE {}
-        virtual bool assertionEnded( AssertionStats const& _assertionStats ) CATCH_OVERRIDE {
+        virtual bool assertionEnded( AssertionStats const& ) CATCH_OVERRIDE {
             return false;
         }
     };

--- a/single_include/catch.hpp
+++ b/single_include/catch.hpp
@@ -1,6 +1,6 @@
 /*
  *  Catch v1.2.1-develop.14
- *  Generated: 2015-09-27 03:27:04.922060
+ *  Generated: 2015-10-29 00:52:04.464709
  *  ----------------------------------------------------------
  *  This file has been merged from multiple headers. Please don't edit it directly
  *  Copyright (c) 2012 Two Blue Cubes Ltd. All rights reserved.
@@ -8246,7 +8246,7 @@ namespace Catch {
         {}
 
         virtual void assertionStarting( AssertionInfo const& ) CATCH_OVERRIDE {}
-        virtual bool assertionEnded( AssertionStats const& _assertionStats ) CATCH_OVERRIDE {
+        virtual bool assertionEnded( AssertionStats const& ) CATCH_OVERRIDE {
             return false;
         }
     };


### PR DESCRIPTION
Just don't name this parameter to avoid warnings about it being unused.

No real changes.