### PR TITLE
don't forward declare as class and define as struct

### DIFF
--- a/include/internal/catch_matchers.hpp
+++ b/include/internal/catch_matchers.hpp
@@ -13,9 +13,9 @@ namespace Matchers {
     namespace Impl {
 
     namespace Generic {
-        template<typename ExpressionT> class AllOf;
-        template<typename ExpressionT> class AnyOf;
-        template<typename ExpressionT> class Not;
+        template<typename ExpressionT> struct AllOf;
+        template<typename ExpressionT> struct AnyOf;
+        template<typename ExpressionT> struct Not;
     }
         
     template<typename ExpressionT>


### PR DESCRIPTION
The forward declaration and the definition of a type shall match regarding the usage of class vs. struct.

Signed-off-by: Stefan Naewe <stefan.naewe@gmail.com>