### PR TITLE
Make buildable with default main() function for Qt5 under Windows

### DIFF
--- a/include/internal/catch_default_main.hpp
+++ b/include/internal/catch_default_main.hpp
@@ -8,17 +8,29 @@
 #ifndef TWOBLUECUBES_CATCH_DEFAULT_MAIN_HPP_INCLUDED
 #define TWOBLUECUBES_CATCH_DEFAULT_MAIN_HPP_INCLUDED
 
+#include "catch_platform.h"
+
+#ifndef CATCH_PLATFORM_WINDOWS
+  #ifndef CATCH_CONFIG_MAIN_ARGV_TYPE
+    #define CATCH_CONFIG_MAIN_ARGV_TYPE char * const
+  #endif
+#else
+  #ifndef CATCH_CONFIG_MAIN_ARGV_TYPE
+    #define CATCH_CONFIG_MAIN_ARGV_TYPE char *
+  #endif
+#endif
+
 #ifndef __OBJC__
 
 // Standard C/C++ main entry point
-int main (int argc, char * const argv[]) {
+int main (int argc, CATCH_CONFIG_MAIN_ARGV_TYPE argv[]) {
     return Catch::Session().run( argc, argv );
 }
 
 #else // __OBJC__
 
 // Objective-C entry point
-int main (int argc, char * const argv[]) {
+int main (int argc, CATCH_CONFIG_MAIN_ARGV_TYPE argv[]) {
 #if !CATCH_ARC_ENABLED
     NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
 #endif


### PR DESCRIPTION
Developer environment: Qt5, MinGW 4.8.2, Windows.
Build with default `char * const` type of `argv` argument for default `main()` method fails with errors: 
```
C:/Qt/Qt5.3.2/5.3/mingw482_32/lib/libqtmaind.a(qtmain_win.o): In function `WinMain@16'
c:\work\build\qt5_workdir\w\s\qtbase\src\winmain/qtmain_win.cpp:131: undefined reference to 'qMain(int, char**)'
error: ld returned 1 exit status
```
I propose using of `CATCH_CONFIG_MAIN_ARGV_TYPE` macro with default value `char * const` for all platforms, except Windows.