### PR TITLE
Re: fixing missing std:: (see #559)

### DIFF
--- a/include/external/clara.h
+++ b/include/external/clara.h
@@ -35,6 +35,7 @@
 #define TBC_TEXT_FORMAT_H_INCLUDED
 #endif
 
+#include <cctype>
 #include <string>
 #include <vector>
 #include <sstream>
@@ -232,7 +233,7 @@ namespace Clara {
         }
         inline void convertInto( std::string const& _source, bool& _dest ) {
             std::string sourceLC = _source;
-            std::transform( sourceLC.begin(), sourceLC.end(), sourceLC.begin(), ::tolower );
+            std::transform( sourceLC.begin(), sourceLC.end(), sourceLC.begin(), std::tolower );
             if( sourceLC == "y" || sourceLC == "1" || sourceLC == "true" || sourceLC == "yes" || sourceLC == "on" )
                 _dest = true;
             else if( sourceLC == "n" || sourceLC == "0" || sourceLC == "false" || sourceLC == "no" || sourceLC == "off" )

--- a/include/external/clara.h
+++ b/include/external/clara.h
@@ -232,7 +232,7 @@ namespace Clara {
         }
         inline void convertInto( std::string const& _source, bool& _dest ) {
             std::string sourceLC = _source;
-            std::transform( sourceLC.begin(), sourceLC.end(), sourceLC.begin(), ::tolower );
+            std::transform( sourceLC.begin(), sourceLC.end(), sourceLC.begin(), std::tolower );
             if( sourceLC == "y" || sourceLC == "1" || sourceLC == "true" || sourceLC == "yes" || sourceLC == "on" )
                 _dest = true;
             else if( sourceLC == "n" || sourceLC == "0" || sourceLC == "false" || sourceLC == "no" || sourceLC == "off" )

--- a/include/external/clara.h
+++ b/include/external/clara.h
@@ -232,7 +232,7 @@ namespace Clara {
         }
         inline void convertInto( std::string const& _source, bool& _dest ) {
             std::string sourceLC = _source;
-            std::transform( sourceLC.begin(), sourceLC.end(), sourceLC.begin(), std::tolower );
+            std::transform( sourceLC.begin(), sourceLC.end(), sourceLC.begin(), ::tolower );
             if( sourceLC == "y" || sourceLC == "1" || sourceLC == "true" || sourceLC == "yes" || sourceLC == "on" )
                 _dest = true;
             else if( sourceLC == "n" || sourceLC == "0" || sourceLC == "false" || sourceLC == "no" || sourceLC == "off" )

--- a/include/external/clara.h
+++ b/include/external/clara.h
@@ -233,7 +233,7 @@ namespace Clara {
         }
         inline void convertInto( std::string const& _source, bool& _dest ) {
             std::string sourceLC = _source;
-            std::transform( sourceLC.begin(), sourceLC.end(), sourceLC.begin(), std::tolower );
+            std::transform( sourceLC.begin(), sourceLC.end(), sourceLC.begin(), static_cast<int(*)(int)>(std::tolower) );
             if( sourceLC == "y" || sourceLC == "1" || sourceLC == "true" || sourceLC == "yes" || sourceLC == "on" )
                 _dest = true;
             else if( sourceLC == "n" || sourceLC == "0" || sourceLC == "false" || sourceLC == "no" || sourceLC == "off" )

--- a/include/internal/catch_approx.hpp
+++ b/include/internal/catch_approx.hpp
@@ -43,7 +43,7 @@ namespace Detail {
 
         friend bool operator == ( double lhs, Approx const& rhs ) {
             // Thanks to Richard Harris for his help refining this formula
-            return fabs( lhs - rhs.m_value ) < rhs.m_epsilon * (rhs.m_scale + (std::max)( fabs(lhs), fabs(rhs.m_value) ) );
+            return std::fabs( lhs - rhs.m_value ) < rhs.m_epsilon * (rhs.m_scale + (std::max)( std::fabs(lhs), std::fabs(rhs.m_value) ) );
         }
 
         friend bool operator == ( Approx const& lhs, double rhs ) {

--- a/include/internal/catch_common.hpp
+++ b/include/internal/catch_common.hpp
@@ -8,6 +8,8 @@
 #ifndef TWOBLUECUBES_CATCH_COMMON_HPP_INCLUDED
 #define TWOBLUECUBES_CATCH_COMMON_HPP_INCLUDED
 
+#include <cctype>
+
 #include "catch_common.h"
 
 namespace Catch {
@@ -22,7 +24,7 @@ namespace Catch {
         return s.find( infix ) != std::string::npos;
     }
     void toLowerInPlace( std::string& s ) {
-        std::transform( s.begin(), s.end(), s.begin(), ::tolower );
+        std::transform( s.begin(), s.end(), s.begin(), std::tolower );
     }
     std::string toLower( std::string const& s ) {
         std::string lc = s;

--- a/include/internal/catch_common.hpp
+++ b/include/internal/catch_common.hpp
@@ -22,7 +22,7 @@ namespace Catch {
         return s.find( infix ) != std::string::npos;
     }
     void toLowerInPlace( std::string& s ) {
-        std::transform( s.begin(), s.end(), s.begin(), std::tolower );
+        std::transform( s.begin(), s.end(), s.begin(), ::tolower );
     }
     std::string toLower( std::string const& s ) {
         std::string lc = s;

--- a/include/internal/catch_common.hpp
+++ b/include/internal/catch_common.hpp
@@ -22,7 +22,7 @@ namespace Catch {
         return s.find( infix ) != std::string::npos;
     }
     void toLowerInPlace( std::string& s ) {
-        std::transform( s.begin(), s.end(), s.begin(), ::tolower );
+        std::transform( s.begin(), s.end(), s.begin(), std::tolower );
     }
     std::string toLower( std::string const& s ) {
         std::string lc = s;

--- a/include/internal/catch_common.hpp
+++ b/include/internal/catch_common.hpp
@@ -24,7 +24,7 @@ namespace Catch {
         return s.find( infix ) != std::string::npos;
     }
     void toLowerInPlace( std::string& s ) {
-        std::transform( s.begin(), s.end(), s.begin(), std::tolower );
+        std::transform( s.begin(), s.end(), s.begin(), static_cast<int(*)(int)>(std::tolower) );
     }
     std::string toLower( std::string const& s ) {
         std::string lc = s;

--- a/include/internal/catch_test_case_info.hpp
+++ b/include/internal/catch_test_case_info.hpp
@@ -30,7 +30,7 @@ namespace Catch {
             return TestCaseInfo::None;
     }
     inline bool isReservedTag( std::string const& tag ) {
-        return parseSpecialTag( tag ) == TestCaseInfo::None && tag.size() > 0 && !isalnum( tag[0] );
+        return parseSpecialTag( tag ) == TestCaseInfo::None && tag.size() > 0 && !std::isalnum( tag[0] );
     }
     inline void enforceNotReservedTag( std::string const& tag, SourceLineInfo const& _lineInfo ) {
         if( isReservedTag( tag ) ) {

--- a/include/reporters/catch_reporter_bases.hpp
+++ b/include/reporters/catch_reporter_bases.hpp
@@ -224,7 +224,7 @@ namespace Catch {
     char const* getLineOfChars() {
         static char line[CATCH_CONFIG_CONSOLE_WIDTH] = {0};
         if( !*line ) {
-            memset( line, C, CATCH_CONFIG_CONSOLE_WIDTH-1 );
+            std::memset( line, C, CATCH_CONFIG_CONSOLE_WIDTH-1 );
             line[CATCH_CONFIG_CONSOLE_WIDTH-1] = 0;
         }
         return line;


### PR DESCRIPTION
The original #544 got prematurely closed, appears this is the only way to reopen.

**The main criticism of this pull request**:

```
static_cast<int(*)(int)>(std::tolower)
```

This is due to there being two std::tolower functions:

```
 std::tolower(int)
charT tolower( charT ch, const locale& loc );
```

A cast is necessary to tell the compiler to disambiguate which function pointer we are taking.

I propose this change be taken at this time as it resolves the compatibility issues but a new issue should be raised to discuss the best solution as whether to keep, or change to use a function object that calls the std::tolower internally or other viable alternatives. 
