### PR TITLE
Lazily stringify expressions

### DIFF
--- a/include/internal/catch_capture.hpp
+++ b/include/internal/catch_capture.hpp
@@ -133,7 +133,7 @@
         try { \
             std::string matcherAsString = (matcher).toString(); \
             __catchResult \
-                .setLhs( Catch::toString( arg ) ) \
+                .setLhs( arg ) \
                 .setRhs( matcherAsString == Catch::Detail::unprintableString ? #matcher : matcherAsString ) \
                 .setOp( "matches" ) \
                 .setResultType( (matcher).match( arg ) ); \

--- a/include/internal/catch_expression_lhs.hpp
+++ b/include/internal/catch_expression_lhs.hpp
@@ -71,7 +71,7 @@ public:
     void endExpression() {
         bool value = m_lhs ? true : false;
         m_rb
-            .setLhs( Catch::toString( value ) )
+            .setLhs( value )
             .setResultType( value )
             .endExpression();
     }
@@ -90,8 +90,8 @@ private:
     ResultBuilder& captureExpression( RhsT const& rhs ) {
         return m_rb
             .setResultType( Internal::compare<Op>( m_lhs, rhs ) )
-            .setLhs( Catch::toString( m_lhs ) )
-            .setRhs( Catch::toString( rhs ) )
+            .setLhs( m_lhs )
+            .setRhs( rhs )
             .setOp( Internal::OperatorTraits<Op>::getName() );
     }
 

--- a/include/internal/catch_result_builder.h
+++ b/include/internal/catch_result_builder.h
@@ -40,10 +40,19 @@ namespace Catch {
     };
 
     template <typename T>
+    struct Decay { typedef T type; };
+
+    template <typename T>
+    struct Decay<T[]> { typedef T* type; };
+
+    template <typename T, size_t N>
+    struct Decay<T[N]> { typedef T* type; };
+
+    template <typename T>
     struct AnyTypeHolder : AnyTypeHolderBase {
         AnyTypeHolder( const T& value ) : value ( value ) {}
         std::string toString() { return Catch::toString( value ); }
-        T value;
+        const typename Decay<const T>::type value;
     };
 
     class ResultBuilder {

--- a/include/internal/catch_result_builder.h
+++ b/include/internal/catch_result_builder.h
@@ -12,6 +12,7 @@
 #include "catch_assertionresult.h"
 #include "catch_common.h"
 #include "catch_matchers.hpp"
+#include "catch_tostring.h"
 
 namespace Catch {
 
@@ -32,6 +33,17 @@ namespace Catch {
             return *this;
         }
         std::ostringstream oss;
+    };
+
+    struct AnyTypeHolderBase {
+        virtual std::string toString() = 0;
+    };
+
+    template <typename T>
+    struct AnyTypeHolder : AnyTypeHolderBase {
+        AnyTypeHolder( const T& value ) : value ( value ) {}
+        std::string toString() { return Catch::toString( value ); }
+        T value;
     };
 
     class ResultBuilder {
@@ -57,8 +69,10 @@ namespace Catch {
 
         ResultBuilder& setResultType( ResultWas::OfType result );
         ResultBuilder& setResultType( bool result );
-        ResultBuilder& setLhs( std::string const& lhs );
-        ResultBuilder& setRhs( std::string const& rhs );
+        template <typename T>
+        ResultBuilder& setLhs( T const& lhs );
+        template <typename T>
+        ResultBuilder& setRhs( T const& rhs );
         ResultBuilder& setOp( std::string const& op );
 
         void endExpression();
@@ -80,9 +94,11 @@ namespace Catch {
         AssertionInfo m_assertionInfo;
         AssertionResultData m_data;
         struct ExprComponents {
-            ExprComponents() : testFalse( false ) {}
+            ExprComponents() : testFalse( false ), lhs( NULL ), rhs( NULL ) {}
+            ~ExprComponents() { delete lhs; delete rhs;  }
             bool testFalse;
-            std::string lhs, rhs, op;
+            std::string op;
+            AnyTypeHolderBase* lhs, *rhs;
         } m_exprComponents;
         CopyableStream m_stream;
 

--- a/include/internal/catch_result_builder.h
+++ b/include/internal/catch_result_builder.h
@@ -79,9 +79,15 @@ namespace Catch {
         ResultBuilder& setResultType( ResultWas::OfType result );
         ResultBuilder& setResultType( bool result );
         template <typename T>
-        ResultBuilder& setLhs( T const& lhs );
+        ResultBuilder& setLhs( T const& lhs ) {
+            m_exprComponents.lhs = new AnyTypeHolder<T>( lhs );
+            return *this;
+        }
         template <typename T>
-        ResultBuilder& setRhs( T const& rhs );
+        ResultBuilder& setRhs( T const& rhs ) {
+            m_exprComponents.rhs = new AnyTypeHolder<T>( rhs );
+            return *this;
+        }
         ResultBuilder& setOp( std::string const& op );
 
         void endExpression();

--- a/include/internal/catch_result_builder.hpp
+++ b/include/internal/catch_result_builder.hpp
@@ -41,16 +41,6 @@ namespace Catch {
         m_data.resultType = result ? ResultWas::Ok : ResultWas::ExpressionFailed;
         return *this;
     }
-    template <typename T>
-    ResultBuilder& ResultBuilder::setLhs( T const& lhs ) {
-        m_exprComponents.lhs = new AnyTypeHolder<T>( lhs );
-        return *this;
-    }
-    template <typename T>
-    ResultBuilder& ResultBuilder::setRhs( T const& rhs ) {
-        m_exprComponents.rhs = new AnyTypeHolder<T>( rhs );
-        return *this;
-    }
     ResultBuilder& ResultBuilder::setOp( std::string const& op ) {
         m_exprComponents.op = op;
         return *this;


### PR DESCRIPTION
Closes #556. With a trimmed down version of the example @scross99 gave (with fewer vector elements), the time to run the test case went down by half!

It works by using type erasure to save the original given value, only converting it to a string if the test actually fails.

I tried to honor your coding convention as much as possible, so forgive me if I missed something...
