### PR TITLE
Implement support for breaking into debugger under Linux

### DIFF
--- a/include/internal/catch_debugger.h
+++ b/include/internal/catch_debugger.h
@@ -25,29 +25,29 @@ namespace Catch{
     // http://cocoawithlove.com/2008/03/break-into-debugger.html
     #ifdef DEBUG
         #if defined(__ppc64__) || defined(__ppc__)
-            #define CATCH_BREAK_INTO_DEBUGGER() \
-                if( Catch::isDebuggerActive() ) { \
+            #define CATCH_TRAP() \
                     __asm__("li r0, 20\nsc\nnop\nli r0, 37\nli r4, 2\nsc\nnop\n" \
-                    : : : "memory","r0","r3","r4" ); \
-                }
+                    : : : "memory","r0","r3","r4" )
         #else
-            #define CATCH_BREAK_INTO_DEBUGGER() if( Catch::isDebuggerActive() ) {__asm__("int $3\n" : : );}
+            #define CATCH_TRAP() _asm__("int $3\n" : : )
         #endif
     #endif
 
 #elif defined(CATCH_PLATFORM_LINUX)
     #include <signal.h>
 
-    #define CATCH_BREAK_INTO_DEBUGGER() if( Catch::isDebuggerActive() ) { raise(SIGTRAP); }
+    #define CATCH_TRAP() raise(SIGTRAP)
 #elif defined(_MSC_VER)
-    #define CATCH_BREAK_INTO_DEBUGGER() if( Catch::isDebuggerActive() ) { __debugbreak(); }
+    #define CATCH_TRAP() __debugbreak()
 #elif defined(__MINGW32__)
     extern "C" __declspec(dllimport) void __stdcall DebugBreak();
-    #define CATCH_BREAK_INTO_DEBUGGER() if( Catch::isDebuggerActive() ) { DebugBreak(); }
+    #define CATCH_TRAP() DebugBreak()
 #endif
 
-#ifndef CATCH_BREAK_INTO_DEBUGGER
-#define CATCH_BREAK_INTO_DEBUGGER() Catch::alwaysTrue();
+#ifdef CATCH_TRAP
+    #define CATCH_BREAK_INTO_DEBUGGER() if( Catch::isDebuggerActive() ) { CATCH_TRAP(); }
+#else
+    #define CATCH_BREAK_INTO_DEBUGGER() Catch::alwaysTrue();
 #endif
 
 #endif // TWOBLUECUBES_CATCH_DEBUGGER_H_INCLUDED

--- a/include/internal/catch_debugger.h
+++ b/include/internal/catch_debugger.h
@@ -34,9 +34,16 @@ namespace Catch{
     #endif
 
 #elif defined(CATCH_PLATFORM_LINUX)
-    #include <signal.h>
+    // If we can use inline assembler, do it because this allows us to break
+    // directly at the location of the failing check instead of breaking inside
+    // raise() called from it, i.e. one stack frame below.
+    #if defined(__GNUC__) && (defined(__i386) || defined(__x86_64))
+        #define CATCH_TRAP() asm volatile ("int $3")
+    #else // Fall back to the generic way.
+        #include <signal.h>
 
-    #define CATCH_TRAP() raise(SIGTRAP)
+        #define CATCH_TRAP() raise(SIGTRAP)
+    #endif
 #elif defined(_MSC_VER)
     #define CATCH_TRAP() __debugbreak()
 #elif defined(__MINGW32__)

--- a/include/internal/catch_debugger.h
+++ b/include/internal/catch_debugger.h
@@ -35,6 +35,10 @@ namespace Catch{
         #endif
     #endif
 
+#elif defined(CATCH_PLATFORM_LINUX)
+    #include <signal.h>
+
+    #define CATCH_BREAK_INTO_DEBUGGER() if( Catch::isDebuggerActive() ) { raise(SIGTRAP); }
 #elif defined(_MSC_VER)
     #define CATCH_BREAK_INTO_DEBUGGER() if( Catch::isDebuggerActive() ) { __debugbreak(); }
 #elif defined(__MINGW32__)

--- a/include/internal/catch_platform.h
+++ b/include/internal/catch_platform.h
@@ -15,6 +15,8 @@
 #define CATCH_PLATFORM_IPHONE
 #elif defined(WIN32) || defined(__WIN32__) || defined(_WIN32) || defined(_MSC_VER)
 #define CATCH_PLATFORM_WINDOWS
+#elif defined(linux) || defined(__linux) || defined(__linux__)
+#define CATCH_PLATFORM_LINUX
 #endif
 
 #endif // TWOBLUECUBES_CATCH_PLATFORM_H_INCLUDED


### PR DESCRIPTION
This makes `-b` command line option to work under Linux.

Only tested under amd64, but should work on any architectures, in theory.
