### PR TITLE
Fix out_of_range exception coming from Tbc::Text

### DIFF
--- a/include/external/tbc_text_format.h
+++ b/include/external/tbc_text_format.h
@@ -77,9 +77,9 @@ namespace Tbc {
                 pos = remainder.find_last_of( _attr.tabChar, width );
                 if( pos != std::string::npos ) {
                     tabPos = pos;
-                    if( remainder[width] == '\n' )
+                    if( width == remainder.size() || remainder[width] == '\n' )
                         width--;
-                    remainder = remainder.substr( 0, tabPos ) + remainder.substr( tabPos+1 );
+                    remainder.erase( tabPos, 1 );
                 }
 
                 if( width == remainder.size() ) {
@@ -104,7 +104,7 @@ namespace Tbc {
                     }
                     if( lines.size() == 1 )
                         indent = _attr.indent;
-                    if( tabPos != std::string::npos )
+                    if( tabPos < _attr.width - indent )
                         indent += tabPos;
                 }
             }

--- a/projects/SelfTest/TestMain.cpp
+++ b/projects/SelfTest/TestMain.cpp
@@ -300,7 +300,13 @@ TEST_CASE( "Long strings can be wrapped", "[wrap]" ) {
             == "one two three\n        four\n        five\n        six" );
     }
 
+    SECTION( "Wrapping near tab doesn't extract substrings from invalid positions", "" ) {
 
+        CHECK_NOTHROW( Text( "one\ttwo", TextAttributes().setWidth( 2 ) ).toString() );
+        CHECK_NOTHROW( Text( "one\ttwo", TextAttributes().setWidth( 3 ) ).toString() );
+        CHECK_NOTHROW( Text( "one\ttwo", TextAttributes().setWidth( 4 ) ).toString() );
+        CHECK_NOTHROW( Text( "one\ttwo", TextAttributes().setWidth( 5 ) ).toString() );
+    }
 }
 
 using namespace Catch;


### PR DESCRIPTION
This fixes two bugs in Tbc::Text

**1)** The first bug is subtle, and probably un-checkable by unit test. There's a possibility of undefined behaviour at [tbc_text_format.h#L88](https://github.com/philsquared/Catch/blob/3b4edd7a4849e05fd9d006bf652190729a32906f/include/external/tbc_text_format.h#L88), here's what leads to it:

``` c++
// assume width == remainder.size()
pos = remainder.find_last_of( _attr.tabChar, width );
// assume tabChar was found
if( pos != std::string::npos ) { 
    tabPos = pos;
    if( remainder[width] == '\n' ) // remainder[width] == '\0', width won't be decremented
        width--;
    remainder = remainder.substr( 0, tabPos ) + remainder.substr( tabPos+1 ); // ***
    // now width == remainder.size() + 1
}   

if( width == remainder.size() ) { // it's greater, not equal
    spliceLine( indent, remainder, width );
}   
else if( remainder[width] == '\n' ) { // remainder[remainder.size() + 1] !!!
```

If, at the line marked `***`, there was `remainder.erase( tabPos, 1 )`, then the line marked `!!!` wouldn't be _undefined behaviour_, because `erase` doesn't deallocate memory -- it'd just be reading garbage. But because in C++11 `***` move-assigns from rvalue, you can't safely read beyond its terminating NUL -- its original internal buffer might've been thrown away and the one from the rvalue (whose size including terminating NUL may be exactly width), taken.

**2)** The second bug causes passing "-1" position to `substr` when a tab character appears at `remainder[width]`.

``` c++
// assume width == _attr.width - indent
// assume remainder[width] == _attr.tabChar
pos = remainder.find_last_of( _attr.tabChar, width );
...
// tabPos == width
if( tabPos != std::string::npos )
    indent += tabPos; // now indent == _attr.width
```

In the next round, width will be zero, and [spliceLine( indent, remainder, width-1 )](https://github.com/philsquared/Catch/blob/3b4edd7a4849e05fd9d006bf652190729a32906f/include/external/tbc_text_format.h#L102) will throw `out_of_range`.
