### PR TITLE
Capitalize "GCC" in pragma

### DIFF
--- a/include/internal/catch_compiler_capabilities.h
+++ b/include/internal/catch_compiler_capabilities.h
@@ -86,7 +86,7 @@
 #   endif
 
 #   if !defined(CATCH_INTERNAL_SUPPRESS_PARENTHESES_WARNINGS) && defined(CATCH_CPP11_OR_GREATER)
-#       define CATCH_INTERNAL_SUPPRESS_PARENTHESES_WARNINGS _Pragma( "gcc diagnostic ignored \"-Wparentheses\"" )
+#       define CATCH_INTERNAL_SUPPRESS_PARENTHESES_WARNINGS _Pragma( "GCC diagnostic ignored \"-Wparentheses\"" )
 #   endif
 
 // - otherwise more recent versions define __cplusplus >= 201103L


### PR DESCRIPTION
This fixes issue #600.  The [documentation of GCC](https://gcc.gnu.org/onlinedocs/gcc/Diagnostic-Pragmas.html) makes it look like "GCC" needs to be capitalized in this pragma.  If you don't capitalize the pragma, GCC warns that it doesn't recognize the pragma.