### PR TITLE
Fixed warning for missing CATCH_OVERRIDE

### DIFF
--- a/include/reporters/catch_reporter_bases.hpp
+++ b/include/reporters/catch_reporter_bases.hpp
@@ -166,7 +166,7 @@ namespace Catch {
 
         virtual void assertionStarting( AssertionInfo const& ) CATCH_OVERRIDE {}
 
-        virtual bool assertionEnded( AssertionStats const& assertionStats ) {
+        virtual bool assertionEnded( AssertionStats const& assertionStats ) CATCH_OVERRIDE {
             assert( !m_sectionStack.empty() );
             SectionNode& sectionNode = *m_sectionStack.back();
             sectionNode.assertions.push_back( assertionStats );


### PR DESCRIPTION
Added missing CATCH_OVERRIDE to CumulativeReporterBase::assertionEnded(). This fixes a warning when building in Xcode 7.2+ with default warning settings.