### PR TITLE
Promote interface to parent class instead of using dynamic_cast

### DIFF
--- a/include/internal/catch_interfaces_reporter.h
+++ b/include/internal/catch_interfaces_reporter.h
@@ -226,6 +226,13 @@ namespace Catch
         // Implementing class must also provide the following static method:
         // static std::string getDescription();
 
+        virtual bool supportsChainedReporters() const {
+            return false;
+        }
+
+        virtual void addChainedReporter( Ptr<IStreamingReporter> const& reporter ) {
+        }
+
         virtual ReporterPreferences getPreferences() const = 0;
 
         virtual void noMatchingTestCases( std::string const& spec ) = 0;

--- a/include/reporters/catch_reporter_multi.hpp
+++ b/include/reporters/catch_reporter_multi.hpp
@@ -22,6 +22,13 @@ public:
     }
 
 public: // IStreamingReporter
+    virtual bool supportsChainedReporters() const CATCH_OVERRIDE {
+        return true;
+    }
+
+    virtual void addChainedReporter( Ptr<IStreamingReporter> const& reporter ) CATCH_OVERRIDE {
+        add( reporter );
+    }
 
     virtual ReporterPreferences getPreferences() const CATCH_OVERRIDE {
         return m_reporters[0]->getPreferences();
@@ -124,16 +131,15 @@ Ptr<IStreamingReporter> addReporter( Ptr<IStreamingReporter> const& existingRepo
     Ptr<IStreamingReporter> resultingReporter;
 
     if( existingReporter ) {
-        MultipleReporters* multi = dynamic_cast<MultipleReporters*>( existingReporter.get() );
-        if( !multi ) {
-            multi = new MultipleReporters;
+        if( !existingReporter->supportsChainedReporters() ) {
+            MultipleReporters* multi = new MultipleReporters;
             resultingReporter = Ptr<IStreamingReporter>( multi );
             if( existingReporter )
-                multi->add( existingReporter );
+                multi->addChainedReporter( existingReporter );
         }
         else
             resultingReporter = existingReporter;
-        multi->add( additionalReporter );
+        resultingReporter->addChainedReporter( additionalReporter );
     }
     else
         resultingReporter = additionalReporter;

--- a/include/reporters/catch_reporter_multi.hpp
+++ b/include/reporters/catch_reporter_multi.hpp
@@ -128,23 +128,18 @@ public: // IStreamingReporter
 };
 
 Ptr<IStreamingReporter> addReporter( Ptr<IStreamingReporter> const& existingReporter, Ptr<IStreamingReporter> const& additionalReporter ) {
-    Ptr<IStreamingReporter> resultingReporter;
+    if( !existingReporter )
+        return additionalReporter;
 
-    if( existingReporter ) {
-        if( !existingReporter->supportsChainedReporters() ) {
-            MultipleReporters* multi = new MultipleReporters;
-            resultingReporter = Ptr<IStreamingReporter>( multi );
-            if( existingReporter )
-                multi->addChainedReporter( existingReporter );
-        }
-        else
-            resultingReporter = existingReporter;
-        resultingReporter->addChainedReporter( additionalReporter );
+    if( existingReporter->supportsChainedReporters() ) {
+        existingReporter->addChainedReporter( additionalReporter );
+        return existingReporter;
     }
-    else
-        resultingReporter = additionalReporter;
 
-    return resultingReporter;
+    Ptr<MultipleReporters> multi = Ptr<MultipleReporters>( new MultipleReporters );
+    multi->addChainedReporter( existingReporter );
+    multi->addChainedReporter( additionalReporter );
+    return Ptr<IStreamingReporter>( multi.get() );
 }
 
 


### PR DESCRIPTION
This eliminates one use of RTTI. Along with another pull request I will send shortly, this makes it possible to compile Catch with gcc and -fno-rtti.

I also did a clean-up while I was there (in the second commit). That cleanup could be done without eliminating the dynamic_cast, too.