### PR TITLE
Fix warning: conversion from 'int' to 'char', possible loss of data.

### DIFF
--- a/include/external/clara.h
+++ b/include/external/clara.h
@@ -375,6 +375,10 @@ namespace Clara {
             return str.size() >= prefix.size() && str.substr( 0, prefix.size() ) == prefix;
         }
 
+        inline char tolower(char ch) {
+            return (char)::tolower(ch);
+        }
+
         template<typename T> struct RemoveConstRef{ typedef T type; };
         template<typename T> struct RemoveConstRef<T&>{ typedef T type; };
         template<typename T> struct RemoveConstRef<T const&>{ typedef T type; };
@@ -396,7 +400,7 @@ namespace Clara {
         }
         inline void convertInto( std::string const& _source, bool& _dest ) {
             std::string sourceLC = _source;
-            std::transform( sourceLC.begin(), sourceLC.end(), sourceLC.begin(), ::tolower );
+            std::transform( sourceLC.begin(), sourceLC.end(), sourceLC.begin(), tolower );
             if( sourceLC == "y" || sourceLC == "1" || sourceLC == "true" || sourceLC == "yes" || sourceLC == "on" )
                 _dest = true;
             else if( sourceLC == "n" || sourceLC == "0" || sourceLC == "false" || sourceLC == "no" || sourceLC == "off" )

--- a/include/internal/catch_common.hpp
+++ b/include/internal/catch_common.hpp
@@ -11,7 +11,6 @@
 #include "catch_common.h"
 
 namespace Catch {
-
     bool startsWith( std::string const& s, std::string const& prefix ) {
         return s.size() >= prefix.size() && s.substr( 0, prefix.size() ) == prefix;
     }
@@ -21,8 +20,11 @@ namespace Catch {
     bool contains( std::string const& s, std::string const& infix ) {
         return s.find( infix ) != std::string::npos;
     }
+    char tolower(char ch) {
+        return (char)::tolower(ch);
+    }
     void toLowerInPlace( std::string& s ) {
-        std::transform( s.begin(), s.end(), s.begin(), ::tolower );
+        std::transform( s.begin(), s.end(), s.begin(), tolower );
     }
     std::string toLower( std::string const& s ) {
         std::string lc = s;


### PR DESCRIPTION
Root cause:
The return type of ::tolower is int. So when we use ::tolower in
std::transform(), it will generate this warning. If user turns on "treat
warning as error", Catch build will fail due to this warning.
