### PR TITLE
Put quote marks around printed characters; also nicely print some escapes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ matrix:
       compiler: clang
       addons: &clang38
         apt:
-          sources: ['llvm-toolchain-precise', 'ubuntu-toolchain-r-test']
+          sources: ['llvm-toolchain-precise-3.8', 'ubuntu-toolchain-r-test']
           packages: ['clang-3.8']
       env: COMPILER='ccache clang++-3.8' BUILD_TYPE='Release'
 

--- a/include/internal/catch_tostring.hpp
+++ b/include/internal/catch_tostring.hpp
@@ -149,9 +149,19 @@ std::string toString( bool value ) {
 }
 
 std::string toString( char value ) {
-    return value < ' '
-        ? toString( static_cast<unsigned int>( value ) )
-        : Detail::makeString( value );
+    if ( value == '\r' )
+        return "'\\r'";
+    if ( value == '\l' )
+        return "'\\l'";
+    if ( value == '\n' )
+        return "'\\n'";
+    if ( value == '\t' )
+        return "'\\t'";
+    if ( '\0' <= value && value < ' ' )
+        return toString( static_cast<unsigned int>( value ) );
+    char chstr[] = "' '";
+    chstr[1] = value;
+    return chstr;
 }
 
 std::string toString( signed char value ) {


### PR DESCRIPTION
This change puts quote marks around printed characters in expression expansions. Previously, for instance,
`REQUIRE('\0'=='0');`
would result in the confusing expansion
`0 == 0`
It now results in
`0 == '0'`
(The initial impetus for this change was a case in which a type was an alias for unsigned char, and the two values happened to be `' '` and `'0'`, thus resulting in `== 0`, which confused me for a while. The expansion `' ' == '0'` is much clearer.)
