### PR TITLE
Pins LLVM 3.8 (stable) instead of tracking the nightly repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ matrix:
       compiler: clang
       addons: &clang38
         apt:
-          sources: ['llvm-toolchain-precise', 'ubuntu-toolchain-r-test']
+          sources: ['llvm-toolchain-precise-3.8', 'ubuntu-toolchain-r-test']
           packages: ['clang-3.8']
       env: COMPILER='ccache clang++-3.8' BUILD_TYPE='Release'
 


### PR DESCRIPTION
Resolves https://github.com/philsquared/Catch/commit/e904aa7f6e2e450f9515bce96a0c4b5669ed5d93#commitcomment-17389109.

Context: when LLVM released LLVM 3.8 they switched the repository `llvm-toolchain-precise` to track LLVM 3.9 and created a `llvm-toolchain-precise-3.8` for LLVM 3.8.