### PR TITLE
Fix string [] access beyond range. cppcheck complains. 

### DIFF
--- a/include/external/clara.h
+++ b/include/external/clara.h
@@ -550,7 +550,7 @@ namespace Clara {
         }
 
         void parseIntoTokens( std::string const& arg, std::vector<Token>& tokens ) {
-            for( std::size_t i = 0; i <= arg.size(); ++i ) {
+            for( std::size_t i = 0; i < arg.size(); ++i ) {
                 char c = arg[i];
                 if( c == '"' )
                     inQuotes = !inQuotes;


### PR DESCRIPTION
Fix string iteration accesses null terminator. cppcheck complains.

Alternatively, if this is intentional, a comment would be appreciated, such as: 

```
for( std::size_t i = 0; i <= arg.size(); ++i ) { // intentional access of terminating-'\0'
```
