### PR TITLE
--list-test-names-and-sources

### DIFF
--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -22,6 +22,7 @@ Click one of the followings links to take you straight to that option - or scrol
 
 <a href="#list-test-names-and-sources">                 `    --list-test-names-and-sources`</a><br />
 <a href="#list-test-names-only">                        `    --list-test-names-only`</a><br />
+<a href="#list-tests-and-sources">                      `    --list-tests-and-sources`</a><br />
 <a href="#listing-available-tests-tags-or-reporters">   `    --list-reporters`</a><br />
 <a href="#order">                                       `    --order`</a><br />
 <a href="#rng-seed">                                    `    --rng-seed`</a><br />
@@ -188,6 +189,12 @@ This option lists all available tests in a non-indented form on one line followe
 <pre>--list-test-names-only</pre>
 
 This option lists all available tests in a non-indented form, one on each line. This makes it ideal for saving to a file and feeding back into the <a href="#input-file">```-f``` or ```--input-file```</a> option.
+
+<a id="list-tests-and-sources"></a>
+## Just test names
+<pre>--list-tests-and-sources</pre>
+
+Equivalent to <a href="#listing-available-tests-tags-or-reporters">```-l``` or ```--list-tests```</a> with the source files included.
 
 
 <a id="order"></a>

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -20,6 +20,7 @@ Click one of the followings links to take you straight to that option - or scrol
 
 </br>
 
+<a href="#list-test-names-and-sources">                 `    --list-test-names-and-sources`</a><br />
 <a href="#list-test-names-only">                        `    --list-test-names-only`</a><br />
 <a href="#listing-available-tests-tags-or-reporters">   `    --list-reporters`</a><br />
 <a href="#order">                                       `    --order`</a><br />
@@ -175,6 +176,12 @@ When set to ```yes``` Catch will report the duration of each test case, in milli
 Provide the name of a file that contains a list of test case names - one per line. Blank lines are skipped and anything after the comment character, ```#```, is ignored.
 
 A useful way to generate an initial instance of this file is to use the <a href="#list-test-names-only">list-test-names-only</a> option. This can then be manually curated to specify a specific subset of tests - or in a specific order.
+
+<a id="list-test-names-and-sources"></a>
+## Test names and source files
+<pre>--list-test-names-and-sources</pre>
+
+This option lists all available tests in a non-indented form on one line followed by it's source file and line number on the next line.
 
 <a id="list-test-names-only"></a>
 ## Just test names

--- a/include/internal/catch_commandline.hpp
+++ b/include/internal/catch_commandline.hpp
@@ -174,9 +174,9 @@ namespace Catch {
             .bind( &ConfigData::filenamesAsTags );
 
         // Less common commands which don't have a short form
-		cli["--list-test-names-and-sources"]
-			.describe("list all/matching test cases names along with their source files")
-			.bind(&ConfigData::listTestNamesAndSources);
+        cli["--list-test-names-and-sources"]
+            .describe("list all/matching test cases names along with their source files")
+            .bind(&ConfigData::listTestNamesAndSources);
 
         cli["--list-test-names-only"]
             .describe( "list all/matching test cases names only" )

--- a/include/internal/catch_commandline.hpp
+++ b/include/internal/catch_commandline.hpp
@@ -174,6 +174,10 @@ namespace Catch {
             .bind( &ConfigData::filenamesAsTags );
 
         // Less common commands which don't have a short form
+		cli["--list-test-names-and-sources"]
+			.describe("list all/matching test cases names along with their source files")
+			.bind(&ConfigData::listTestNamesAndSources);
+
         cli["--list-test-names-only"]
             .describe( "list all/matching test cases names only" )
             .bind( &ConfigData::listTestNamesOnly );

--- a/include/internal/catch_commandline.hpp
+++ b/include/internal/catch_commandline.hpp
@@ -182,6 +182,10 @@ namespace Catch {
             .describe( "list all/matching test cases names only" )
             .bind( &ConfigData::listTestNamesOnly );
 
+        cli["--list-tests-and-sources"]
+            .describe( "list all/matching test cases and their source files" )
+            .bind( &ConfigData::listTestSources );
+
         cli["--list-reporters"]
             .describe( "list all reporters" )
             .bind( &ConfigData::listReporters );

--- a/include/internal/catch_config.hpp
+++ b/include/internal/catch_config.hpp
@@ -33,6 +33,7 @@ namespace Catch {
             listReporters( false ),
             listTestNamesAndSources( false ),
             listTestNamesOnly( false ),
+            listTestSources( false ),
             showSuccessfulTests( false ),
             shouldDebugBreak( false ),
             noThrow( false ),
@@ -52,6 +53,7 @@ namespace Catch {
         bool listTags;
         bool listReporters;
         bool listTestNamesAndSources;
+        bool listTestSources;
         bool listTestNamesOnly;
 
         bool showSuccessfulTests;
@@ -111,6 +113,7 @@ namespace Catch {
         bool listTests() const { return m_data.listTests; }
         bool listTestNamesAndSources() const { return m_data.listTestNamesAndSources; }
         bool listTestNamesOnly() const { return m_data.listTestNamesOnly; }
+        bool listTestSources() const { return m_data.listTestSources; }
         bool listTags() const { return m_data.listTags; }
         bool listReporters() const { return m_data.listReporters; }
 

--- a/include/internal/catch_config.hpp
+++ b/include/internal/catch_config.hpp
@@ -31,7 +31,7 @@ namespace Catch {
         :   listTests( false ),
             listTags( false ),
             listReporters( false ),
-			listTestNamesAndSources( false ),
+            listTestNamesAndSources( false ),
             listTestNamesOnly( false ),
             showSuccessfulTests( false ),
             shouldDebugBreak( false ),
@@ -51,8 +51,8 @@ namespace Catch {
         bool listTests;
         bool listTags;
         bool listReporters;
-		bool listTestNamesAndSources;
-		bool listTestNamesOnly;
+        bool listTestNamesAndSources;
+        bool listTestNamesOnly;
 
         bool showSuccessfulTests;
         bool shouldDebugBreak;
@@ -109,7 +109,7 @@ namespace Catch {
         }
 
         bool listTests() const { return m_data.listTests; }
-		bool listTestNamesAndSources() const { return m_data.listTestNamesAndSources; }
+        bool listTestNamesAndSources() const { return m_data.listTestNamesAndSources; }
         bool listTestNamesOnly() const { return m_data.listTestNamesOnly; }
         bool listTags() const { return m_data.listTags; }
         bool listReporters() const { return m_data.listReporters; }

--- a/include/internal/catch_config.hpp
+++ b/include/internal/catch_config.hpp
@@ -31,6 +31,7 @@ namespace Catch {
         :   listTests( false ),
             listTags( false ),
             listReporters( false ),
+			listTestNamesAndSources( false ),
             listTestNamesOnly( false ),
             showSuccessfulTests( false ),
             shouldDebugBreak( false ),
@@ -50,7 +51,8 @@ namespace Catch {
         bool listTests;
         bool listTags;
         bool listReporters;
-        bool listTestNamesOnly;
+		bool listTestNamesAndSources;
+		bool listTestNamesOnly;
 
         bool showSuccessfulTests;
         bool shouldDebugBreak;
@@ -107,6 +109,7 @@ namespace Catch {
         }
 
         bool listTests() const { return m_data.listTests; }
+		bool listTestNamesAndSources() const { return m_data.listTestNamesAndSources; }
         bool listTestNamesOnly() const { return m_data.listTestNamesOnly; }
         bool listTags() const { return m_data.listTags; }
         bool listReporters() const { return m_data.listReporters; }

--- a/include/internal/catch_config.hpp
+++ b/include/internal/catch_config.hpp
@@ -54,7 +54,7 @@ namespace Catch {
         bool listReporters;
         bool listTestNamesAndSources;
         bool listTestNamesOnly;
-		bool listTestSources;
+        bool listTestSources;
 
         bool showSuccessfulTests;
         bool shouldDebugBreak;

--- a/include/internal/catch_config.hpp
+++ b/include/internal/catch_config.hpp
@@ -53,8 +53,8 @@ namespace Catch {
         bool listTags;
         bool listReporters;
         bool listTestNamesAndSources;
-        bool listTestSources;
         bool listTestNamesOnly;
+		bool listTestSources;
 
         bool showSuccessfulTests;
         bool shouldDebugBreak;

--- a/include/internal/catch_list.hpp
+++ b/include/internal/catch_list.hpp
@@ -19,13 +19,15 @@
 
 namespace Catch {
 
-    inline std::size_t listTests( Config const& config ) {
+    inline std::size_t listTests( Config const& config, const bool includeSources ) {
 
         TestSpec testSpec = config.testSpec();
         if( config.testSpec().hasFilters() )
+            if( !includeSources )
             Catch::cout() << "Matching test cases:\n";
         else {
-            Catch::cout() << "All available test cases:\n";
+            if( !includeSources )
+              Catch::cout() << "All available test cases:\n";
             testSpec = TestSpecParser( ITagAliasRegistry::get() ).parse( "*" ).testSpec();
         }
 
@@ -48,6 +50,8 @@ namespace Catch {
             Catch::cout() << Text( testCaseInfo.name, nameAttr ) << std::endl;
             if( !testCaseInfo.tags.empty() )
                 Catch::cout() << Text( testCaseInfo.tagsAsString, tagsAttr ) << std::endl;
+            if( includeSources )
+                Catch::cout() << testCaseInfo.lineInfo << std::endl;
         }
 
         if( !config.testSpec().hasFilters() )
@@ -163,11 +167,13 @@ namespace Catch {
     inline Option<std::size_t> list( Config const& config ) {
         Option<std::size_t> listedCount;
         if( config.listTests() )
-            listedCount = listedCount.valueOr(0) + listTests( config );
+            listedCount = listedCount.valueOr(0) + listTests( config , false );
         if( config.listTestNamesAndSources() )
-            listedCount = listedCount.valueOr(0) + listTestsNames(config, true);
+            listedCount = listedCount.valueOr(0) + listTestsNames( config, true );
         if( config.listTestNamesOnly() )
-            listedCount = listedCount.valueOr(0) + listTestsNames( config , false );
+            listedCount = listedCount.valueOr(0) + listTestsNames( config, false );
+        if( config.listTestSources() )
+            listedCount = listedCount.valueOr(0) + listTests( config, true );
         if( config.listTags() )
             listedCount = listedCount.valueOr(0) + listTags( config );
         if( config.listReporters() )

--- a/include/internal/catch_list.hpp
+++ b/include/internal/catch_list.hpp
@@ -22,12 +22,12 @@ namespace Catch {
     inline std::size_t listTests( Config const& config, const bool includeSources ) {
 
         TestSpec testSpec = config.testSpec();
-        if( config.testSpec().hasFilters() )
+        if( config.testSpec().hasFilters() ) {
             if( !includeSources )
-            Catch::cout() << "Matching test cases:\n";
-        else {
+                Catch::cout() << "Matching test cases:\n";
+        } else {
             if( !includeSources )
-              Catch::cout() << "All available test cases:\n";
+                Catch::cout() << "All available test cases:\n";
             testSpec = TestSpecParser( ITagAliasRegistry::get() ).parse( "*" ).testSpec();
         }
 

--- a/include/internal/catch_list.hpp
+++ b/include/internal/catch_list.hpp
@@ -57,21 +57,23 @@ namespace Catch {
         return matchedTests;
     }
 
-    inline std::size_t listTestsNamesOnly( Config const& config ) {
-        TestSpec testSpec = config.testSpec();
-        if( !config.testSpec().hasFilters() )
-            testSpec = TestSpecParser( ITagAliasRegistry::get() ).parse( "*" ).testSpec();
-        std::size_t matchedTests = 0;
-        std::vector<TestCase> matchedTestCases = filterTests( getAllTestCasesSorted( config ), testSpec, config );
-        for( std::vector<TestCase>::const_iterator it = matchedTestCases.begin(), itEnd = matchedTestCases.end();
-                it != itEnd;
-                ++it ) {
-            matchedTests++;
-            TestCaseInfo const& testCaseInfo = it->getTestCaseInfo();
-            Catch::cout() << testCaseInfo.name << std::endl;
-        }
-        return matchedTests;
-    }
+	inline std::size_t listTestsNames( Config const& config , const bool includeSources ) {
+		TestSpec testSpec = config.testSpec();
+		if( !config.testSpec().hasFilters() )
+			testSpec = TestSpecParser( ITagAliasRegistry::get() ).parse( "*" ).testSpec();
+		std::size_t matchedTests = 0;
+		std::vector<TestCase> matchedTestCases = filterTests( getAllTestCasesSorted( config ), testSpec, config );
+		for( std::vector<TestCase>::const_iterator it = matchedTestCases.begin(), itEnd = matchedTestCases.end();
+			it != itEnd;
+			++it ) {
+			matchedTests++;
+			TestCaseInfo const& testCaseInfo = it->getTestCaseInfo();
+			Catch::cout() << testCaseInfo.name << std::endl;
+			if( includeSources )
+				Catch::cout() << testCaseInfo.lineInfo << std::endl;
+		}
+		return matchedTests;
+	}
 
     struct TagInfo {
         TagInfo() : count ( 0 ) {}
@@ -163,7 +165,9 @@ namespace Catch {
         if( config.listTests() )
             listedCount = listedCount.valueOr(0) + listTests( config );
         if( config.listTestNamesOnly() )
-            listedCount = listedCount.valueOr(0) + listTestsNamesOnly( config );
+            listedCount = listedCount.valueOr(0) + listTestsNames( config , false );
+		if( config.listTestNamesAndSources() )
+			listedCount = listedCount.valueOr(0) + listTestsNames( config , true );
         if( config.listTags() )
             listedCount = listedCount.valueOr(0) + listTags( config );
         if( config.listReporters() )

--- a/include/internal/catch_list.hpp
+++ b/include/internal/catch_list.hpp
@@ -53,11 +53,12 @@ namespace Catch {
             if( includeSources )
                 Catch::cout() << testCaseInfo.lineInfo << std::endl;
         }
-
-        if( !config.testSpec().hasFilters() )
-            Catch::cout() << pluralise( matchedTests, "test case" ) << "\n" << std::endl;
-        else
-            Catch::cout() << pluralise( matchedTests, "matching test case" ) << "\n" << std::endl;
+        if ( !includeSources ) {
+            if( !config.testSpec().hasFilters() )
+                Catch::cout() << pluralise( matchedTests, "test case" ) << "\n" << std::endl;
+            else
+                Catch::cout() << pluralise( matchedTests, "matching test case" ) << "\n" << std::endl;
+        }
         return matchedTests;
     }
 

--- a/include/internal/catch_list.hpp
+++ b/include/internal/catch_list.hpp
@@ -57,23 +57,23 @@ namespace Catch {
         return matchedTests;
     }
 
-	inline std::size_t listTestsNames( Config const& config , const bool includeSources ) {
-		TestSpec testSpec = config.testSpec();
-		if( !config.testSpec().hasFilters() )
-			testSpec = TestSpecParser( ITagAliasRegistry::get() ).parse( "*" ).testSpec();
-		std::size_t matchedTests = 0;
-		std::vector<TestCase> matchedTestCases = filterTests( getAllTestCasesSorted( config ), testSpec, config );
-		for( std::vector<TestCase>::const_iterator it = matchedTestCases.begin(), itEnd = matchedTestCases.end();
-			it != itEnd;
-			++it ) {
-			matchedTests++;
-			TestCaseInfo const& testCaseInfo = it->getTestCaseInfo();
-			Catch::cout() << testCaseInfo.name << std::endl;
-			if( includeSources )
-				Catch::cout() << testCaseInfo.lineInfo << std::endl;
-		}
-		return matchedTests;
-	}
+    inline std::size_t listTestsNames( Config const& config , const bool includeSources ) {
+        TestSpec testSpec = config.testSpec();
+        if( !config.testSpec().hasFilters() )
+            testSpec = TestSpecParser( ITagAliasRegistry::get() ).parse( "*" ).testSpec();
+        std::size_t matchedTests = 0;
+        std::vector<TestCase> matchedTestCases = filterTests( getAllTestCasesSorted( config ), testSpec, config );
+        for( std::vector<TestCase>::const_iterator it = matchedTestCases.begin(), itEnd = matchedTestCases.end();
+            it != itEnd;
+            ++it ) {
+            matchedTests++;
+            TestCaseInfo const& testCaseInfo = it->getTestCaseInfo();
+            Catch::cout() << testCaseInfo.name << std::endl;
+            if( includeSources )
+                Catch::cout() << testCaseInfo.lineInfo << std::endl;
+        }
+        return matchedTests;
+    }
 
     struct TagInfo {
         TagInfo() : count ( 0 ) {}
@@ -164,10 +164,10 @@ namespace Catch {
         Option<std::size_t> listedCount;
         if( config.listTests() )
             listedCount = listedCount.valueOr(0) + listTests( config );
+        if( config.listTestNamesAndSources() )
+            listedCount = listedCount.valueOr(0) + listTestsNames(config, true);
         if( config.listTestNamesOnly() )
             listedCount = listedCount.valueOr(0) + listTestsNames( config , false );
-		if( config.listTestNamesAndSources() )
-			listedCount = listedCount.valueOr(0) + listTestsNames( config , true );
         if( config.listTags() )
             listedCount = listedCount.valueOr(0) + listTags( config );
         if( config.listReporters() )


### PR DESCRIPTION
I'm working on a Visual Studio unit test adapter for Catch and was looking for a way to view the source file and line of a test without actually running it. So I implemented this

Sample output:

Scenario: Test that threaded operations can be canceled
s:\documents\actual documents\da git\cyberenginemkiii\tests\platform\system\threads.cpp(78)
Scenario: Test basic sleep works
s:\documents\actual documents\da git\cyberenginemkiii\tests\platform\system\threads.cpp(109)
Scenario: Test basic yield works
s:\documents\actual documents\da git\cyberenginemkiii\tests\platform\system\threads.cpp(126)
Scenario: Test thread system errors work
s:\documents\actual documents\da git\cyberenginemkiii\tests\platform\system\threads.cpp(150)
