### PR TITLE
Modified team city reporter to report testIgnored if it was skipped

### DIFF
--- a/include/reporters/catch_reporter_teamcity.hpp
+++ b/include/reporters/catch_reporter_teamcity.hpp
@@ -134,10 +134,21 @@ namespace Catch {
                         "  " << result.getExpandedExpression() << "\n";
                 }
 
+				// If we're allowing this to fail, report it as an ignored test in team city
+				if (currentTestCaseInfo->okToFail())
+				{
+					stream << "##teamcity[testIgnored"
+						<< " name='" << escape(currentTestCaseInfo->name) << "'"
+						<< " message='" << escape(std::string("[FailedButIgnored] ") + msg.str()) << "'"
+						<< "]\n";
+				}
+				else
+				{
                 stream << "##teamcity[testFailed"
                     << " name='" << escape( currentTestCaseInfo->name )<< "'"
                     << " message='" << escape( msg.str() ) << "'"
                     << "]\n";
+				}
             }
             return true;
         }

--- a/include/reporters/catch_reporter_teamcity.hpp
+++ b/include/reporters/catch_reporter_teamcity.hpp
@@ -134,21 +134,21 @@ namespace Catch {
                         "  " << result.getExpandedExpression() << "\n";
                 }
 
-				// If we're allowing this to fail, report it as an ignored test in team city
-				if (currentTestCaseInfo->okToFail())
-				{
-					stream << "##teamcity[testIgnored"
-						<< " name='" << escape(currentTestCaseInfo->name) << "'"
-						<< " message='" << escape(std::string("[FailedButIgnored] ") + msg.str()) << "'"
-						<< "]\n";
-				}
-				else
-				{
+                // If we're allowing this to fail, report it as an ignored test in team city
+                if (currentTestCaseInfo->okToFail())
+                {
+                    stream << "##teamcity[testIgnored"
+                        << " name='" << escape(currentTestCaseInfo->name) << "'"
+                        << " message='" << escape(std::string("[FailedButIgnored] ") + msg.str()) << "'"
+                        << "]\n";
+                }
+                else
+                {
                 stream << "##teamcity[testFailed"
                     << " name='" << escape( currentTestCaseInfo->name )<< "'"
                     << " message='" << escape( msg.str() ) << "'"
                     << "]\n";
-				}
+                }
             }
             return true;
         }


### PR DESCRIPTION
TeamCity was always running tests and reporting them as failed, even though locally the [!mayfail] tag prevented them from failing (and just printed the output).

This change makes such cases report as testIgnored, which in team city still shows the test assertion but does not treat it as an error, mirroring what the local console run does.
