### PR TITLE
Add INTERNAL_CATCH_UNIQUE_NAME prefix support.

### DIFF
--- a/include/internal/catch_common.h
+++ b/include/internal/catch_common.h
@@ -9,7 +9,7 @@
 #define TWOBLUECUBES_CATCH_COMMON_H_INCLUDED
 
 /// @see https://github.com/pfultz2/Cloak/wiki/C-Preprocessor-tricks,-tips,-and-idioms
-#define INTERNAL_CATCH_CAT(a, ...) CATCH_PRIMITIVE_CAT(a, __VA_ARGS__)
+#define INTERNAL_CATCH_CAT(a, ...) INTERNAL_CATCH_PRIMITIVE_CAT(a, __VA_ARGS__)
 #define INTERNAL_CATCH_PRIMITIVE_CAT(a, ...) a ## __VA_ARGS__
 
 #ifndef CATCH_BRANCH_PREFIX

--- a/include/internal/catch_common.h
+++ b/include/internal/catch_common.h
@@ -8,7 +8,15 @@
 #ifndef TWOBLUECUBES_CATCH_COMMON_H_INCLUDED
 #define TWOBLUECUBES_CATCH_COMMON_H_INCLUDED
 
-#define INTERNAL_CATCH_UNIQUE_NAME_LINE2( name, line ) name##line
+/// @see https://github.com/pfultz2/Cloak/wiki/C-Preprocessor-tricks,-tips,-and-idioms
+#define INTERNAL_CATCH_CAT(a, ...) CATCH_PRIMITIVE_CAT(a, __VA_ARGS__)
+#define INTERNAL_CATCH_PRIMITIVE_CAT(a, ...) a ## __VA_ARGS__
+
+#ifndef CATCH_BRANCH_PREFIX
+#	define CATCH_BRANCH_PREFIX
+#endif 
+
+#define INTERNAL_CATCH_UNIQUE_NAME_LINE2( name, line ) INTERNAL_CATCH_CAT(CATCH_BRANCH_PREFIX, name##line)
 #define INTERNAL_CATCH_UNIQUE_NAME_LINE( name, line ) INTERNAL_CATCH_UNIQUE_NAME_LINE2( name, line )
 #ifdef CATCH_CONFIG_COUNTER
 #  define INTERNAL_CATCH_UNIQUE_NAME( name ) INTERNAL_CATCH_UNIQUE_NAME_LINE( name, __COUNTER__ )


### PR DESCRIPTION
when you compile the same test with different flags (CPU feature dispatch), the MSVC 2015 Update2 linker complains about redefined symbols.
CLANG and GCC were working before the fix.

CATCH_BRANCH_PREFIX must be defined BEFORE including catch.

[Example usage](https://github.com/zz-systems/gorynych/blob/develop/gorynych-test/test_extensions.h)
