### PR TITLE
Fix misindent in internal/catch_test_spec.hpp:70

### DIFF
--- a/include/internal/catch_test_spec.hpp
+++ b/include/internal/catch_test_spec.hpp
@@ -67,7 +67,7 @@ namespace Catch {
                 for( std::vector<Ptr<Pattern> >::const_iterator it = m_patterns.begin(), itEnd = m_patterns.end(); it != itEnd; ++it )
                     if( !(*it)->matches( testCase ) )
                         return false;
-                    return true;
+                return true;
             }
         };
 


### PR DESCRIPTION
This (and all bugs akin) could (and honestly should) be fixed by enforcing a `.clang-format` at repository root

Closes #679 