### PR TITLE
Fix grammar error in tutorial.md

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -233,7 +233,7 @@ The requirement is that the following block of code ([or equivalent](own-main.md
 
 appears in _exactly one_ source file. Use as many additional cpp files (or whatever you call your implementation files) as you need for your tests, partitioned however makes most sense for your way of working. Each additional file need only ```#include "catch.hpp"``` - do not repeat the ```#define```!
 
-In fact it is usually a good idea to put the block with the ```#define``` [in it's own source file](slow-compiles.md).
+In fact it is usually a good idea to put the block with the ```#define``` [in its own source file](slow-compiles.md).
 
 Do not write your tests in header files!
 


### PR DESCRIPTION
It's = it is
its = possessive it
In the sentence "In fact it is usually a good idea to put the block with the `#define` [in it's own source file](slow-compiles.md).", the correct usage is "its", not "it's".
