### PR TITLE
Fix build error on VS 2015 with Clang/C2

### DIFF
--- a/include/internal/catch_console_colour_impl.hpp
+++ b/include/internal/catch_console_colour_impl.hpp
@@ -48,6 +48,7 @@ namespace Catch {
 #ifdef __AFXDLL
 #include <AfxWin.h>
 #else
+struct IUnknown;
 #include <windows.h>
 #endif
 


### PR DESCRIPTION
Fixes #690 due to unknown type IUnknown in Windows.h header
