### PR TITLE
Fix Visual Studio analyze warnings

### DIFF
--- a/include/internal/catch_debugger.hpp
+++ b/include/internal/catch_debugger.hpp
@@ -82,7 +82,12 @@
 #endif // Platform
 
 #ifdef CATCH_PLATFORM_WINDOWS
-    extern "C" __declspec(dllimport) void __stdcall OutputDebugStringA( const char* );
+    #if defined(_MSC_VER) && _MSC_VER >= 1700 
+    #define CATCH_INTERNAL_WINDOWS_SAL_IN_OPT _In_opt_
+    #else
+    #define CATCH_INTERNAL_WINDOWS_SAL_IN_OPT
+    #endif
+    extern "C" __declspec(dllimport) void __stdcall OutputDebugStringA( CATCH_INTERNAL_WINDOWS_SAL_IN_OPT const char* );
     namespace Catch {
         void writeToDebugConsole( std::string const& text ) {
             ::OutputDebugStringA( text.c_str() );

--- a/include/internal/catch_test_case_info.hpp
+++ b/include/internal/catch_test_case_info.hpp
@@ -30,7 +30,7 @@ namespace Catch {
             return TestCaseInfo::None;
     }
     inline bool isReservedTag( std::string const& tag ) {
-        return parseSpecialTag( tag ) == TestCaseInfo::None && tag.size() > 0 && !isalnum( tag[0] );
+        return parseSpecialTag( tag ) == TestCaseInfo::None && tag.size() > 0 && !isalnum( static_cast<unsigned char>(tag[0]) );
     }
     inline void enforceNotReservedTag( std::string const& tag, SourceLineInfo const& _lineInfo ) {
         if( isReservedTag( tag ) ) {


### PR DESCRIPTION
This fixes warnings reported by Visual Studio's static analysis enabled by the "/analyze" compiler switch.
