### PR TITLE
Fix fix implicit narrowing warnings in Catch

### DIFF
--- a/include/internal/catch_common.hpp
+++ b/include/internal/catch_common.hpp
@@ -21,9 +21,11 @@ namespace Catch {
     bool contains( std::string const& s, std::string const& infix ) {
         return s.find( infix ) != std::string::npos;
     }
+    char toLowerCh(char c) {
+        return static_cast<char>( ::tolower( c ) );
+    }
     void toLowerInPlace( std::string& s ) {
-        std::transform( s.begin(), s.end(), s.begin(),
-            [](char c) { return static_cast<char>(::tolower(c)); } );
+        std::transform( s.begin(), s.end(), s.begin(), toLowerCh );
     }
     std::string toLower( std::string const& s ) {
         std::string lc = s;

--- a/include/internal/catch_common.hpp
+++ b/include/internal/catch_common.hpp
@@ -22,7 +22,8 @@ namespace Catch {
         return s.find( infix ) != std::string::npos;
     }
     void toLowerInPlace( std::string& s ) {
-        std::transform( s.begin(), s.end(), s.begin(), ::tolower );
+        std::transform( s.begin(), s.end(), s.begin(),
+            [](char c) { return static_cast<char>(::tolower(c)); } );
     }
     std::string toLower( std::string const& s ) {
         std::string lc = s;

--- a/include/internal/catch_test_case_registry_impl.hpp
+++ b/include/internal/catch_test_case_registry_impl.hpp
@@ -24,9 +24,9 @@
 #endif
 
 namespace Catch {
-    
+
     struct RandomNumberGenerator {
-        typedef int result_type;
+        typedef std::ptrdiff_t result_type;
 
         result_type operator()( result_type n ) const { return std::rand() % n; }
 


### PR DESCRIPTION
We (the Visual Studio STL team) are trying to remove suppression of C4244 in `<algorithm>`, which exposed stealth narrowing conversions in Catch.