### PR TITLE
Fixed function signature in the code snippet

### DIFF
--- a/docs/tostring.md
+++ b/docs/tostring.md
@@ -33,7 +33,7 @@ If you don't want to provide an ```operator <<``` overload, or you want to conve
 
 ```
 namespace Catch {
-	std::string toString( T const& value ) {
+	template<> std::string toString( T const& value ) {
 		return convertMyTypeToString( value );
 	}
 }


### PR DESCRIPTION
Since the 'toString' is a template function specialization, it should
have a 'template<>' statement in it's declaration.
