### PR TITLE
Fixes build error caused by missing include.

### DIFF
--- a/include/internal/catch_stream.h
+++ b/include/internal/catch_stream.h
@@ -15,6 +15,7 @@
 #include <streambuf>
 #include <ostream>
 #include <fstream>
+#include <memory>
 
 namespace Catch {
 


### PR DESCRIPTION
This fixes issue #749.

However, I think it would be better to `#include <memory>` when defining `CATCH_AUTO_PTR` macro, instead of forcing catch headers to include `<memory>` when using the macro.