### PR TITLE
Added signal handling under Windows.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -148,7 +148,8 @@ install:
       mkdir cmake && travis_retry wget --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake
       export PATH=${DEPS_DIR}/cmake/bin:${PATH}
     elif [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
-      brew install cmake ccache
+      which cmake || brew install cmake 
+      which ccache || brew install ccache
     fi
 
 before_script:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![catch logo](catch-logo-small.png)
 
-*v1.5.7*
+*v1.5.8*
 
 Build status (on Travis CI) [![Build Status](https://travis-ci.org/philsquared/Catch.png)](https://travis-ci.org/philsquared/Catch)
 

--- a/include/internal/catch_common.hpp
+++ b/include/internal/catch_common.hpp
@@ -21,9 +21,11 @@ namespace Catch {
     bool contains( std::string const& s, std::string const& infix ) {
         return s.find( infix ) != std::string::npos;
     }
+    char toLowerCh(char c) {
+        return static_cast<char>( ::tolower( c ) );
+    }
     void toLowerInPlace( std::string& s ) {
-        std::transform( s.begin(), s.end(), s.begin(),
-            [](char c) { return static_cast<char>(::tolower(c)); } );
+        std::transform( s.begin(), s.end(), s.begin(), toLowerCh );
     }
     std::string toLower( std::string const& s ) {
         std::string lc = s;

--- a/include/internal/catch_common.hpp
+++ b/include/internal/catch_common.hpp
@@ -22,7 +22,8 @@ namespace Catch {
         return s.find( infix ) != std::string::npos;
     }
     void toLowerInPlace( std::string& s ) {
-        std::transform( s.begin(), s.end(), s.begin(), ::tolower );
+        std::transform( s.begin(), s.end(), s.begin(),
+            [](char c) { return static_cast<char>(::tolower(c)); } );
     }
     std::string toLower( std::string const& s ) {
         std::string lc = s;

--- a/include/internal/catch_fatal_condition.hpp
+++ b/include/internal/catch_fatal_condition.hpp
@@ -28,9 +28,65 @@ namespace Catch {
 
 namespace Catch {
 
+#define NOMINMAX
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#undef WIN32_LEAN_AND_MEAN
+#undef NOMINMAX
+
+
+namespace Catch {
+
+    struct SignalDefs { DWORD id; const char* name; };
+    extern SignalDefs signalDefs[];
+    // There is no 1-1 mapping between signals and windows exceptions.
+    // Windows can easily distinguish between SO and SigSegV,
+    // but SigInt, SigTerm, etc are handled differently.
+    SignalDefs signalDefs[] = {
+        { EXCEPTION_ILLEGAL_INSTRUCTION,  "SIGILL - Illegal instruction signal" },
+        { EXCEPTION_STACK_OVERFLOW, "SIGSEGV - Stack overflow" },
+        { EXCEPTION_ACCESS_VIOLATION, "SIGSEGV - Segmentation violation signal" },
+        { EXCEPTION_INT_DIVIDE_BY_ZERO, "Divide by zero error" },
+    };
+
     struct FatalConditionHandler {
-		void reset() {}
-	};
+
+        static LONG CALLBACK handleVectoredException(PEXCEPTION_POINTERS ExceptionInfo) {
+            for (int i = 0; i < sizeof(signalDefs) / sizeof(SignalDefs); ++i) {
+                if (ExceptionInfo->ExceptionRecord->ExceptionCode == signalDefs[i].id) {
+                    fatal(signalDefs[i].name, -i);
+                }
+            }
+            // If its not an exception we care about, pass it along.
+            // This stops us from eating debugger breaks etc.
+            return EXCEPTION_CONTINUE_SEARCH;
+        }
+
+        // 32k seems enough for Catch to handle stack overflow,
+        // but the value was found experimentally, so there is no strong guarantee
+        FatalConditionHandler():m_isSet(true), m_guaranteeSize(32 * 1024) {
+            // Register as first handler in current chain
+            AddVectoredExceptionHandler(1, handleVectoredException);
+            // Pass in guarantee size to be filled
+            SetThreadStackGuarantee(&m_guaranteeSize);
+        }
+
+        void reset() {
+            if (m_isSet) {
+                // Unregister handler and restore the old guarantee
+                RemoveVectoredExceptionHandler(handleVectoredException);
+                SetThreadStackGuarantee(&m_guaranteeSize);
+                m_isSet = false;
+            }
+        }
+
+        ~FatalConditionHandler() {
+            reset();
+        }
+    private:
+        bool m_isSet;
+        ULONG m_guaranteeSize;
+    };
 
 } // namespace Catch
 

--- a/include/internal/catch_stream.h
+++ b/include/internal/catch_stream.h
@@ -15,6 +15,7 @@
 #include <streambuf>
 #include <ostream>
 #include <fstream>
+#include <memory>
 
 namespace Catch {
 

--- a/include/internal/catch_test_case_registry_impl.hpp
+++ b/include/internal/catch_test_case_registry_impl.hpp
@@ -24,9 +24,9 @@
 #endif
 
 namespace Catch {
-    
+
     struct RandomNumberGenerator {
-        typedef int result_type;
+        typedef std::ptrdiff_t result_type;
 
         result_type operator()( result_type n ) const { return std::rand() % n; }
 

--- a/include/internal/catch_version.hpp
+++ b/include/internal/catch_version.hpp
@@ -37,7 +37,7 @@ namespace Catch {
         return os;
     }
 
-    Version libraryVersion( 1, 5, 7, "", 0 );
+    Version libraryVersion( 1, 5, 8, "", 0 );
 
 }
 

--- a/include/reporters/catch_reporter_xml.hpp
+++ b/include/reporters/catch_reporter_xml.hpp
@@ -115,7 +115,7 @@ namespace Catch {
                         .writeText( assertionResult.getMessage() );
                     break;
                 case ResultWas::FatalErrorCondition:
-                    m_xml.scopedElement( "Fatal Error Condition" )
+                    m_xml.scopedElement( "FatalErrorCondition" )
                         .writeAttribute( "filename", assertionResult.getSourceInfo().file )
                         .writeAttribute( "line", assertionResult.getSourceInfo().line )
                         .writeText( assertionResult.getMessage() );

--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -7,31 +7,51 @@ get_filename_component(CATCH_DIR "${CMAKE_CURRENT_SOURCE_DIR}" PATH)
 get_filename_component(CATCH_DIR "${CATCH_DIR}" PATH)
 set(SELF_TEST_DIR ${CATCH_DIR}/projects/SelfTest)
 if(USE_CPP11)
-  ## We can't turn this on by default, since it breaks on travis
-  message(STATUS "Enabling C++11")
-  set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+    ## We can't turn this on by default, since it breaks on travis
+    message(STATUS "Enabling C++11")
+    set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
 endif()
 
 # define the sources of the self test
 set(SOURCES
-    ${SELF_TEST_DIR}/ApproxTests.cpp
-    ${SELF_TEST_DIR}/BDDTests.cpp
-    ${SELF_TEST_DIR}/ClassTests.cpp
-    ${SELF_TEST_DIR}/ConditionTests.cpp
-    ${SELF_TEST_DIR}/ExceptionTests.cpp
-    ${SELF_TEST_DIR}/GeneratorTests.cpp
-    ${SELF_TEST_DIR}/MessageTests.cpp
-    ${SELF_TEST_DIR}/MiscTests.cpp
-    ${SELF_TEST_DIR}/PartTrackerTests.cpp
-    ${SELF_TEST_DIR}/TestMain.cpp
-    ${SELF_TEST_DIR}/TrickyTests.cpp
-    ${SELF_TEST_DIR}/VariadicMacrosTests.cpp
-    ${SELF_TEST_DIR}/EnumToString.cpp
-    ${SELF_TEST_DIR}/ToStringPair.cpp
-    ${SELF_TEST_DIR}/ToStringVector.cpp
-    ${SELF_TEST_DIR}/ToStringWhich.cpp
-    ${SELF_TEST_DIR}/ToStringTuple.cpp
-)
+        ${SELF_TEST_DIR}/ApproxTests.cpp
+        ${SELF_TEST_DIR}/BDDTests.cpp
+        ${SELF_TEST_DIR}/ClassTests.cpp
+        ${SELF_TEST_DIR}/ConditionTests.cpp
+        ${SELF_TEST_DIR}/ExceptionTests.cpp
+        ${SELF_TEST_DIR}/GeneratorTests.cpp
+        ${SELF_TEST_DIR}/MessageTests.cpp
+        ${SELF_TEST_DIR}/MiscTests.cpp
+        ${SELF_TEST_DIR}/PartTrackerTests.cpp
+        ${SELF_TEST_DIR}/TestMain.cpp
+        ${SELF_TEST_DIR}/TrickyTests.cpp
+        ${SELF_TEST_DIR}/VariadicMacrosTests.cpp
+        ${SELF_TEST_DIR}/EnumToString.cpp
+        ${SELF_TEST_DIR}/ToStringPair.cpp
+        ${SELF_TEST_DIR}/ToStringVector.cpp
+        ${SELF_TEST_DIR}/ToStringWhich.cpp
+        ${SELF_TEST_DIR}/ToStringTuple.cpp
+        ${SELF_TEST_DIR}/CmdLineTests.cpp
+        ${SELF_TEST_DIR}/TagAliasTests.cpp
+        ${SELF_TEST_DIR}/SurrogateCpps/catch_common.cpp
+        ${SELF_TEST_DIR}/SurrogateCpps/catch_console_colour.cpp
+        ${SELF_TEST_DIR}/SurrogateCpps/catch_debugger.cpp
+        ${SELF_TEST_DIR}/SurrogateCpps/catch_interfaces_capture.cpp
+        ${SELF_TEST_DIR}/SurrogateCpps/catch_interfaces_config.cpp
+        ${SELF_TEST_DIR}/SurrogateCpps/catch_interfaces_exception.cpp
+        ${SELF_TEST_DIR}/SurrogateCpps/catch_interfaces_generators.cpp
+        ${SELF_TEST_DIR}/SurrogateCpps/catch_interfaces_registry_hub.cpp
+        ${SELF_TEST_DIR}/SurrogateCpps/catch_interfaces_reporter.cpp
+        ${SELF_TEST_DIR}/SurrogateCpps/catch_interfaces_runner.cpp
+        ${SELF_TEST_DIR}/SurrogateCpps/catch_interfaces_testcase.cpp
+        ${SELF_TEST_DIR}/SurrogateCpps/catch_message.cpp
+        ${SELF_TEST_DIR}/SurrogateCpps/catch_option.cpp
+        ${SELF_TEST_DIR}/SurrogateCpps/catch_ptr.cpp
+        ${SELF_TEST_DIR}/SurrogateCpps/catch_stream.cpp
+        ${SELF_TEST_DIR}/SurrogateCpps/catch_streambuf.cpp
+        ${SELF_TEST_DIR}/SurrogateCpps/catch_test_spec.cpp
+        ${SELF_TEST_DIR}/SurrogateCpps/catch_xmlwriter.cpp
+        )
 
 # configure the executable
 include_directories(${CATCH_DIR}/include)

--- a/projects/SelfTest/CmdLineTests.cpp
+++ b/projects/SelfTest/CmdLineTests.cpp
@@ -7,7 +7,7 @@
  */
 
 #include "catch.hpp"
-#include "catch_test_spec_parser.hpp"
+#include "internal/catch_test_spec_parser.hpp"
 
 #ifdef __clang__
 #   pragma clang diagnostic ignored "-Wc++98-compat"

--- a/projects/SelfTest/SurrogateCpps/catch_common.cpp
+++ b/projects/SelfTest/SurrogateCpps/catch_common.cpp
@@ -1,3 +1,3 @@
 // This file is only here to verify (to the extent possible) the self sufficiency of the header
-#include "catch_suppress_warnings.h"
-#include "catch_common.h"
+#include "internal/catch_suppress_warnings.h"
+#include "internal/catch_common.h"

--- a/projects/SelfTest/SurrogateCpps/catch_console_colour.cpp
+++ b/projects/SelfTest/SurrogateCpps/catch_console_colour.cpp
@@ -1,3 +1,3 @@
 // This file is only here to verify (to the extent possible) the self sufficiency of the header
-#include "catch_suppress_warnings.h"
-#include "catch_console_colour.hpp"
+#include "internal/catch_suppress_warnings.h"
+#include "internal/catch_console_colour.hpp"

--- a/projects/SelfTest/SurrogateCpps/catch_debugger.cpp
+++ b/projects/SelfTest/SurrogateCpps/catch_debugger.cpp
@@ -1,2 +1,2 @@
 // This file is only here to verify (to the extent possible) the self sufficiency of the header
-#include "catch_debugger.h"
+#include "internal/catch_debugger.h"

--- a/projects/SelfTest/SurrogateCpps/catch_interfaces_capture.cpp
+++ b/projects/SelfTest/SurrogateCpps/catch_interfaces_capture.cpp
@@ -1,3 +1,3 @@
 // This file is only here to verify (to the extent possible) the self sufficiency of the header
-#include "catch_suppress_warnings.h"
-#include "catch_interfaces_capture.h"
+#include "internal/catch_suppress_warnings.h"
+#include "internal/catch_interfaces_capture.h"

--- a/projects/SelfTest/SurrogateCpps/catch_interfaces_config.cpp
+++ b/projects/SelfTest/SurrogateCpps/catch_interfaces_config.cpp
@@ -1,2 +1,2 @@
-#include "catch_suppress_warnings.h"
-#include "catch_interfaces_config.h"
+#include "internal/catch_suppress_warnings.h"
+#include "internal/catch_interfaces_config.h"

--- a/projects/SelfTest/SurrogateCpps/catch_interfaces_exception.cpp
+++ b/projects/SelfTest/SurrogateCpps/catch_interfaces_exception.cpp
@@ -1,2 +1,2 @@
-#include "catch_suppress_warnings.h"
-#include "catch_interfaces_exception.h"
+#include "internal/catch_suppress_warnings.h"
+#include "internal/catch_interfaces_exception.h"

--- a/projects/SelfTest/SurrogateCpps/catch_interfaces_generators.cpp
+++ b/projects/SelfTest/SurrogateCpps/catch_interfaces_generators.cpp
@@ -1,1 +1,1 @@
-#include "catch_interfaces_generators.h"
+#include "internal/catch_interfaces_generators.h"

--- a/projects/SelfTest/SurrogateCpps/catch_interfaces_registry_hub.cpp
+++ b/projects/SelfTest/SurrogateCpps/catch_interfaces_registry_hub.cpp
@@ -1,3 +1,3 @@
 // This file is only here to verify (to the extent possible) the self sufficiency of the header
-#include "catch_suppress_warnings.h"
-#include "catch_interfaces_registry_hub.h"
+#include "internal/catch_suppress_warnings.h"
+#include "internal/catch_interfaces_registry_hub.h"

--- a/projects/SelfTest/SurrogateCpps/catch_interfaces_reporter.cpp
+++ b/projects/SelfTest/SurrogateCpps/catch_interfaces_reporter.cpp
@@ -1,2 +1,2 @@
-#include "catch_suppress_warnings.h"
-#include "catch_interfaces_reporter.h"
+#include "internal/catch_suppress_warnings.h"
+#include "internal/catch_interfaces_reporter.h"

--- a/projects/SelfTest/SurrogateCpps/catch_interfaces_runner.cpp
+++ b/projects/SelfTest/SurrogateCpps/catch_interfaces_runner.cpp
@@ -1,1 +1,1 @@
-#include "catch_interfaces_runner.h"
+#include "internal/catch_interfaces_runner.h"

--- a/projects/SelfTest/SurrogateCpps/catch_interfaces_testcase.cpp
+++ b/projects/SelfTest/SurrogateCpps/catch_interfaces_testcase.cpp
@@ -1,2 +1,2 @@
-#include "catch_suppress_warnings.h"
-#include "catch_interfaces_testcase.h"
+#include "internal/catch_suppress_warnings.h"
+#include "internal/catch_interfaces_testcase.h"

--- a/projects/SelfTest/SurrogateCpps/catch_message.cpp
+++ b/projects/SelfTest/SurrogateCpps/catch_message.cpp
@@ -1,3 +1,3 @@
 // This file is only here to verify (to the extent possible) the self sufficiency of the header
-#include "catch_suppress_warnings.h"
-#include "catch_message.h"
+#include "internal/catch_suppress_warnings.h"
+#include "internal/catch_message.h"

--- a/projects/SelfTest/SurrogateCpps/catch_option.cpp
+++ b/projects/SelfTest/SurrogateCpps/catch_option.cpp
@@ -1,3 +1,3 @@
 // This file is only here to verify (to the extent possible) the self sufficiency of the header
-#include "catch_suppress_warnings.h"
-#include "catch_option.hpp"
+#include "internal/catch_suppress_warnings.h"
+#include "internal/catch_option.hpp"

--- a/projects/SelfTest/SurrogateCpps/catch_ptr.cpp
+++ b/projects/SelfTest/SurrogateCpps/catch_ptr.cpp
@@ -1,3 +1,3 @@
 // This file is only here to verify (to the extent possible) the self sufficiency of the header
-#include "catch_suppress_warnings.h"
-#include "catch_ptr.hpp"
+#include "internal/catch_suppress_warnings.h"
+#include "internal/catch_ptr.hpp"

--- a/projects/SelfTest/SurrogateCpps/catch_stream.cpp
+++ b/projects/SelfTest/SurrogateCpps/catch_stream.cpp
@@ -1,3 +1,3 @@
 // This file is only here to verify (to the extent possible) the self sufficiency of the header
-#include "catch_suppress_warnings.h"
-#include "catch_stream.h"
+#include "internal/catch_suppress_warnings.h"
+#include "internal/catch_stream.h"

--- a/projects/SelfTest/SurrogateCpps/catch_streambuf.cpp
+++ b/projects/SelfTest/SurrogateCpps/catch_streambuf.cpp
@@ -1,3 +1,3 @@
 // This file is only here to verify (to the extent possible) the self sufficiency of the header
-#include "catch_suppress_warnings.h"
-#include "catch_streambuf.h"
+#include "internal/catch_suppress_warnings.h"
+#include "internal/catch_streambuf.h"

--- a/projects/SelfTest/SurrogateCpps/catch_test_spec.cpp
+++ b/projects/SelfTest/SurrogateCpps/catch_test_spec.cpp
@@ -1,3 +1,3 @@
 // This file is only here to verify (to the extent possible) the self sufficiency of the header
-#include "catch_suppress_warnings.h"
-#include "catch_test_spec.hpp"
+#include "internal/catch_suppress_warnings.h"
+#include "internal/catch_test_spec.hpp"

--- a/projects/SelfTest/SurrogateCpps/catch_xmlwriter.cpp
+++ b/projects/SelfTest/SurrogateCpps/catch_xmlwriter.cpp
@@ -1,4 +1,4 @@
 // This file is only here to verify (to the extent possible) the self sufficiency of the header
-#include "catch_suppress_warnings.h"
-#include "catch_xmlwriter.hpp"
-#include "catch_reenable_warnings.h"
+#include "internal/catch_suppress_warnings.h"
+#include "internal/catch_xmlwriter.hpp"
+#include "internal/catch_reenable_warnings.h"

--- a/single_include/catch.hpp
+++ b/single_include/catch.hpp
@@ -1,6 +1,6 @@
 /*
- *  Catch v1.5.7
- *  Generated: 2016-09-27 10:45:46.824849
+ *  Catch v1.5.8
+ *  Generated: 2016-10-26 12:07:30.938259
  *  ----------------------------------------------------------
  *  This file has been merged from multiple headers. Please don't edit it directly
  *  Copyright (c) 2012 Two Blue Cubes Ltd. All rights reserved.
@@ -6461,7 +6461,7 @@ namespace Catch {
 namespace Catch {
 
     struct RandomNumberGenerator {
-        typedef int result_type;
+        typedef std::ptrdiff_t result_type;
 
         result_type operator()( result_type n ) const { return std::rand() % n; }
 
@@ -7578,7 +7578,7 @@ namespace Catch {
         return os;
     }
 
-    Version libraryVersion( 1, 5, 7, "", 0 );
+    Version libraryVersion( 1, 5, 8, "", 0 );
 
 }
 
@@ -7809,8 +7809,11 @@ namespace Catch {
     bool contains( std::string const& s, std::string const& infix ) {
         return s.find( infix ) != std::string::npos;
     }
+    char toLowerCh(char c) {
+        return static_cast<char>( ::tolower( c ) );
+    }
     void toLowerInPlace( std::string& s ) {
-        std::transform( s.begin(), s.end(), s.begin(), ::tolower );
+        std::transform( s.begin(), s.end(), s.begin(), toLowerCh );
     }
     std::string toLower( std::string const& s ) {
         std::string lc = s;
@@ -9258,7 +9261,7 @@ namespace Catch {
                         .writeText( assertionResult.getMessage() );
                     break;
                 case ResultWas::FatalErrorCondition:
-                    m_xml.scopedElement( "Fatal Error Condition" )
+                    m_xml.scopedElement( "FatalErrorCondition" )
                         .writeAttribute( "filename", assertionResult.getSourceInfo().file )
                         .writeAttribute( "line", assertionResult.getSourceInfo().line )
                         .writeText( assertionResult.getMessage() );


### PR DESCRIPTION
Only some "signals" are handled under Windows, because Windows does not
use signals per-se and the mechanics are different. For now, we handle
sigsegv, stack overflow, div-by-zero and sigill. We can also meaningfully
add various floating point errors, but not sigterm and family, because
sigterm is not a structured exception under Windows.

There is also no catch-all, because that would also catch various
debugger-related exceptions, like EXCEPTION_BREAKPOINT.