### PR TITLE
Do not encode extended ASCII characters in XML reporter

### DIFF
--- a/include/internal/catch_xmlwriter.hpp
+++ b/include/internal/catch_xmlwriter.hpp
@@ -57,7 +57,7 @@ namespace Catch {
                     default:
                         // Escape control chars - based on contribution by @espenalb in PR #465 and
                         // by @mrpi PR #588
-                        if ( ( c < '\x09' ) || ( c > '\x0D' && c < '\x20') || c=='\x7F' )
+                        if ( ( c >= 0 && c < '\x09' ) || ( c > '\x0D' && c < '\x20') || c=='\x7F' )
                             os << "&#x" << std::uppercase << std::hex << std::setfill('0') << std::setw(2) << static_cast<int>( c ) << ';';
                         else
                             os << c;


### PR DESCRIPTION
At the moment Catch encodes (assuming signed char) characters from extended ASCII encodings in the XML reporter. This was probably not intended (since only control characters should be escaped), and is also a problem for XML parsers which do not understand XML v1.1 yet (like .NET's XmlReader).