### PR TITLE
CHECK no longer stops running SECTION on exception.

### DIFF
--- a/include/internal/catch_capture.hpp
+++ b/include/internal/catch_capture.hpp
@@ -37,7 +37,7 @@
             ( __catchResult <= expr ).endExpression(); \
         } \
         catch( ... ) { \
-            __catchResult.useActiveException( Catch::ResultDisposition::Normal ); \
+            __catchResult.useActiveException( resultDisposition ); \
         } \
         INTERNAL_CATCH_REACT( __catchResult ) \
     } while( Catch::isTrue( false && !!(expr) ) ) // expr here is never evaluated at runtime but it forces the compiler to give it a look


### PR DESCRIPTION
This seems to be much closer to desired behaviour than the current one, where
CHECK(false) lets the execution continue, but CHECK(throws) does not.