### PR TITLE
use sizeof(expr) for unevaluated syntax check

### DIFF
--- a/include/internal/catch_capture.hpp
+++ b/include/internal/catch_capture.hpp
@@ -40,8 +40,7 @@
             __catchResult.useActiveException( Catch::ResultDisposition::Normal ); \
         } \
         INTERNAL_CATCH_REACT( __catchResult ) \
-    } while( Catch::isTrue( false && static_cast<bool>( !!(expr) ) ) ) // expr here is never evaluated at runtime but it forces the compiler to give it a look
-    // The double negation silences MSVC's C4800 warning, the static_cast forces short-circuit evaluation if the type has overloaded &&.
+    } while( Catch::alwaysFalse( sizeof(expr) ) ) // expr here is never evaluated at runtime but it forces the compiler to give it a look
 
 ///////////////////////////////////////////////////////////////////////////////
 #define INTERNAL_CATCH_IF( expr, resultDisposition, macroName ) \

--- a/include/internal/catch_common.h
+++ b/include/internal/catch_common.h
@@ -116,9 +116,8 @@ namespace Catch {
     std::ostream& operator << ( std::ostream& os, SourceLineInfo const& info );
 
     // This is just here to avoid compiler warnings with macro constants and boolean literals
-    inline bool isTrue( bool value ){ return value; }
-    inline bool alwaysTrue() { return true; }
-    inline bool alwaysFalse() { return false; }
+    inline bool alwaysTrue( std::size_t = 0 ) { return true; }
+    inline bool alwaysFalse( std::size_t = 0 ) { return false; }
 
     void throwLogicError( std::string const& message, SourceLineInfo const& locationInfo );
 


### PR DESCRIPTION
There were numerous different ideas and scattered code snippets in #574. This PR gathers the pieces to implement the `sizeof` approach.