### PR TITLE
Added INSTALL commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,3 +237,6 @@ set_tests_properties(ListTests PROPERTIES PASS_REGULAR_EXPRESSION "[0-9]+ test c
 
 add_test(NAME ListTags COMMAND SelfTest --list-tags)
 set_tests_properties(ListTags PROPERTIES PASS_REGULAR_EXPRESSION "[0-9]+ tags")
+
+install(DIRECTORY "include/" DESTINATION "include/catch")
+install(DIRECTORY "single_include/" DESTINATION "include/catch/single_include/")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,5 +238,4 @@ set_tests_properties(ListTests PROPERTIES PASS_REGULAR_EXPRESSION "[0-9]+ test c
 add_test(NAME ListTags COMMAND SelfTest --list-tags)
 set_tests_properties(ListTags PROPERTIES PASS_REGULAR_EXPRESSION "[0-9]+ tags")
 
-install(DIRECTORY "include/" DESTINATION "include/catch")
-install(DIRECTORY "single_include/" DESTINATION "include/catch/single_include/")
+install(DIRECTORY "single_include/" DESTINATION "include/catch/")


### PR DESCRIPTION
Even though CATCH is a header only library, it makes sense to allow it to INSTALL the includes in a standard manner. This is especially useful when adding dependencies using the CMake ExternalProject_Add command as an example.