### PR TITLE
Enable breaking into debugger on Mac

### DIFF
--- a/include/internal/catch_debugger.h
+++ b/include/internal/catch_debugger.h
@@ -23,14 +23,12 @@ namespace Catch{
 
     // The following code snippet based on:
     // http://cocoawithlove.com/2008/03/break-into-debugger.html
-    #ifdef DEBUG
-        #if defined(__ppc64__) || defined(__ppc__)
-            #define CATCH_TRAP() \
-                    __asm__("li r0, 20\nsc\nnop\nli r0, 37\nli r4, 2\nsc\nnop\n" \
-                    : : : "memory","r0","r3","r4" )
-        #else
-            #define CATCH_TRAP() _asm__("int $3\n" : : )
-        #endif
+    #if defined(__ppc64__) || defined(__ppc__)
+        #define CATCH_TRAP() \
+                __asm__("li r0, 20\nsc\nnop\nli r0, 37\nli r4, 2\nsc\nnop\n" \
+                : : : "memory","r0","r3","r4" )
+    #else
+        #define CATCH_TRAP() __asm__("int $3\n" : : )
     #endif
 
 #elif defined(CATCH_PLATFORM_LINUX)


### PR DESCRIPTION
The integrated assembler segment was missing an underscore:
`"_asm__"`. This regression was accidentally introduced in: https://github.com/philsquared/Catch/commit/25d017763b73e09d3e9adf7f4db9ce71992f0471#diff-96e75ad10f6edace03f2cb7d3607de00L34
Also we remove the "DEBUG" macro check, so we are consistent
with the linux and windows variant.
Now breaking into gdb on failure should work via:
`gdb --args test_executable --break`

I tested this to work on Mac OS 10.11.6 using GNU gdb (GDB) 7.12.