### PR TITLE
Cap main exit code to 255

### DIFF
--- a/docs/own-main.md
+++ b/docs/own-main.md
@@ -45,13 +45,16 @@ int main( int argc, char* argv[] )
 
   int returnCode = session.applyCommandLine( argc, argv );
   if( returnCode != 0 ) // Indicates a command line error
-  	return ( returnCode < 0xff ? returnCode : 0xff );
+  	return returnCode;
 
   // writing to session.configData() or session.Config() here 
   // overrides command line args
   // only do this if you know you need to
 
   int numFailed = session.run();
+  // Note that on unices only the lower 8 bits are usually used, clamping
+  // the return value to 255 prevents false negative when some multiple
+  // of 256 tests has failed
   return ( numFailed < 0xff ? numFailed : 0xff );
 }
 ```

--- a/docs/own-main.md
+++ b/docs/own-main.md
@@ -24,7 +24,7 @@ int main( int argc, char* argv[] )
 
   // global clean-up...
 
-  return result;
+  return ( result < 0xff ? result : 0xff );
 }
 ```
 
@@ -45,13 +45,14 @@ int main( int argc, char* argv[] )
 
   int returnCode = session.applyCommandLine( argc, argv );
   if( returnCode != 0 ) // Indicates a command line error
-  	return returnCode;
+  	return ( returnCode < 0xff ? returnCode : 0xff );
 
   // writing to session.configData() or session.Config() here 
   // overrides command line args
   // only do this if you know you need to
 
-  return session.run();
+  int numFailed = session.run();
+  return ( numFailed < 0xff ? numFailed : 0xff );
 }
 ```
 

--- a/include/internal/catch_default_main.hpp
+++ b/include/internal/catch_default_main.hpp
@@ -12,7 +12,8 @@
 
 // Standard C/C++ main entry point
 int main (int argc, char * argv[]) {
-    return Catch::Session().run( argc, argv );
+    int result = Catch::Session().run( argc, argv );
+    return ( result < 0xff ? result : 0xff );
 }
 
 #else // __OBJC__
@@ -30,7 +31,7 @@ int main (int argc, char * const argv[]) {
     [pool drain];
 #endif
 
-    return result;
+    return ( result < 0xff ? result : 0xff );
 }
 
 #endif // __OBJC__


### PR DESCRIPTION
## Description

According to POSIX, only lower 8-bits of a program exit code are available through `wait()` and `waitpid()` calls. Although there is a newer `waitid()` interface, I think most of the programs still use the old one. As a result, multiples of 256 wrap to 0 for these programs.

This pull request sets cap to 255 for the default main exit code for better compatiblity. Also the documentation for own-main() is updated.

## Reproducer

Tested on macOS Sierra with zsh and Fedora 25 with bash.

```c++
#define CATCH_CONFIG_MAIN
#include <catch.hpp>

TEST_CASE("256 failures")
{
	for (int i = 0; i < 256; i++) {
		CHECK(false);
	}
}
```

```
$ ./before; echo "exit_code: $?"
...
test cases:   1 |   1 failed
assertions: 256 | 256 failed

exit_code: 0
```

```
$ ./after; echo "exit_code: $?"
...
test cases:   1 |   1 failed
assertions: 256 | 256 failed

exit_code: 255
```



