### PR TITLE
Fix single-header download link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 Build status (on Travis CI) [![Build Status](https://travis-ci.org/philsquared/Catch.svg?branch=master)](https://travis-ci.org/philsquared/Catch)
 
-<a href="https://github.com/philsquared/Catch/releases/download/v1.7.0/catch.hpp">The latest, single header, version can be downloaded directly using this link</a>
+<a href="https://github.com/philsquared/Catch/releases/download/v.1.7.0/catch.hpp">The latest, single header, version can be downloaded
+directly using this link</a>
 
 ## What's the Catch?
 


### PR DESCRIPTION
I think you may have made a typo in creating the git tag for for the 1.7.0 release - there is an extra dot between the v and the 1.  This fixes the download link to incorporate the extra dot but you may want to consider re-tagging the release.

