### PR TITLE
fix annoying assignment operator could not be generated warnings in VC2013

### DIFF
--- a/include/internal/catch_expression_lhs.hpp
+++ b/include/internal/catch_expression_lhs.hpp
@@ -27,6 +27,8 @@ class ExpressionLhs : public DecomposedExpression {
 public:
     ExpressionLhs( ResultBuilder& rb, T lhs ) : m_rb( rb ), m_lhs( lhs ), m_truthy(false) {}
 
+    ExpressionLhs& operator = ( const ExpressionLhs& );
+
     template<typename RhsT>
     BinaryExpression<T, Internal::IsEqualTo, RhsT const&>
     operator == ( RhsT const& rhs ) {
@@ -104,6 +106,8 @@ class BinaryExpression : public DecomposedExpression {
 public:
     BinaryExpression( ResultBuilder& rb, LhsT lhs, RhsT rhs )
         : m_rb( rb ), m_lhs( lhs ), m_rhs( rhs ) {}
+
+    BinaryExpression& operator = ( BinaryExpression& );
 
     void endExpression() const {
         m_rb


### PR DESCRIPTION
Fixed annoying `assignment operator could not be generated` warnings in VC2013:
```
warning C4512: 'Catch::ExpressionLhs<A>' : assignment operator could not be generated
warning C4512: 'Catch::BinaryExpression<A>' : assignment operator could not be generated
```

Please, review.

Thank you,
Grigoriy