### PR TITLE
teamcity reporter should time durations explicitly

### DIFF
--- a/include/reporters/catch_reporter_teamcity.hpp
+++ b/include/reporters/catch_reporter_teamcity.hpp
@@ -148,7 +148,7 @@ namespace Catch {
         }
 
         virtual void testCaseStarting( TestCaseInfo const& testInfo ) CATCH_OVERRIDE {
-			testTimer.start();
+            testTimer.start();
             StreamingReporterBase::testCaseStarting( testInfo );
             stream << "##teamcity[testStarted name='"
                 << escape( testInfo.name ) << "']\n";
@@ -165,8 +165,8 @@ namespace Catch {
                     << escape( testCaseStats.testInfo.name )
                     << "' out='" << escape( testCaseStats.stdErr ) << "']\n";
             stream << "##teamcity[testFinished name='"
-                << escape( testCaseStats.testInfo.name ) << "' duration='"
-				<< testTimer.getElapsedMilliseconds() << "']\n";
+                    << escape( testCaseStats.testInfo.name ) << "' duration='"
+                    << testTimer.getElapsedMilliseconds() << "']\n";
         }
 
     private:
@@ -205,7 +205,7 @@ namespace Catch {
         }
     private:
         bool m_headerPrintedForThisSection;
-		Timer testTimer;
+        Timer testTimer;
     };
 
 #ifdef CATCH_IMPL

--- a/include/reporters/catch_reporter_teamcity.hpp
+++ b/include/reporters/catch_reporter_teamcity.hpp
@@ -148,6 +148,7 @@ namespace Catch {
         }
 
         virtual void testCaseStarting( TestCaseInfo const& testInfo ) CATCH_OVERRIDE {
+			testTimer.start();
             StreamingReporterBase::testCaseStarting( testInfo );
             stream << "##teamcity[testStarted name='"
                 << escape( testInfo.name ) << "']\n";
@@ -164,7 +165,8 @@ namespace Catch {
                     << escape( testCaseStats.testInfo.name )
                     << "' out='" << escape( testCaseStats.stdErr ) << "']\n";
             stream << "##teamcity[testFinished name='"
-                << escape( testCaseStats.testInfo.name ) << "']\n";
+                << escape( testCaseStats.testInfo.name ) << "' duration='"
+				<< testTimer.getElapsedMilliseconds() << "']\n";
         }
 
     private:
@@ -203,7 +205,7 @@ namespace Catch {
         }
     private:
         bool m_headerPrintedForThisSection;
-
+		Timer testTimer;
     };
 
 #ifdef CATCH_IMPL


### PR DESCRIPTION
## Description
I've modified the teamcity reporter to time individual test cases. TeamCity can time tests without reporting duration explicitly however the timing can be subject to network latency.

See the teamcity [documentation](https://confluence.jetbrains.com/display/TCD10/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-Supportedtestservicemessages) for the duration attribute on the testFinished service message.
