### PR TITLE
Add parentheses around macro argument "expr"

### DIFF
--- a/include/internal/catch_capture.hpp
+++ b/include/internal/catch_capture.hpp
@@ -44,7 +44,7 @@
         Catch::ResultBuilder __catchResult( macroName, CATCH_INTERNAL_LINEINFO, #expr, resultDisposition ); \
         try { \
             CATCH_INTERNAL_SUPPRESS_PARENTHESES_WARNINGS \
-            ( __catchResult <= expr ).endExpression(); \
+            ( __catchResult <= (expr) ).endExpression(); \
             CATCH_INTERNAL_UNSUPPRESS_PARENTHESES_WARNINGS \
         } \
         catch( ... ) { \


### PR DESCRIPTION
Without paranteses arround the macro argument "expr" the used overloaded operator, the execution order and the resulting type is not clear for all macro substitutions:

Example:

```
expr = a || b:

// Bad:
(__catchResult <= expr ) -> (__catchResult <= a || b )

// Good:
(__catchResult <= (expr) ) -> (__catchResult <= (a || b) )
```

On GCC I get the warning without parentheses: 
warning: suggest parentheses around comparison in operand of ‘==’ [-Wparentheses]