### PR TITLE
Fix Catch::toString() linker error when main() is compiled as C++

### DIFF
--- a/include/internal/catch_tostring.h
+++ b/include/internal/catch_tostring.h
@@ -63,7 +63,7 @@ std::string toString( std::nullptr_t );
 
 #ifdef __OBJC__
     std::string toString( NSString const * const& nsstring );
-    std::string toString( NSString * CATCH_ARC_STRONG const& nsstring );
+    std::string toString( NSString * CATCH_ARC_STRONG & nsstring );
     std::string toString( NSObject* const& nsObject );
 #endif
 

--- a/include/internal/catch_tostring.hpp
+++ b/include/internal/catch_tostring.hpp
@@ -198,7 +198,7 @@ std::string toString( std::nullptr_t ) {
             return "nil";
         return "@" + toString([nsstring UTF8String]);
     }
-    std::string toString( NSString * CATCH_ARC_STRONG const& nsstring ) {
+    std::string toString( NSString * CATCH_ARC_STRONG & nsstring ) {
         if( !nsstring )
             return "nil";
         return "@" + toString([nsstring UTF8String]);


### PR DESCRIPTION
Closes #278