### PR TITLE
Use bulk vector::insert rather than back_inserter

### DIFF
--- a/include/internal/catch_generators.hpp
+++ b/include/internal/catch_generators.hpp
@@ -10,7 +10,6 @@
 
 #include "catch_context.h"
 
-#include <iterator>
 #include <vector>
 #include <string>
 #include <stdlib.h>
@@ -124,7 +123,7 @@ public:
 private:
 
     void move( CompositeGenerator& other ) {
-        std::copy( other.m_composed.begin(), other.m_composed.end(), std::back_inserter( m_composed ) );
+        m_composed.insert( m_composed.end(), other.m_composed.begin(), other.m_composed.end() );
         m_totalSize += other.m_totalSize;
         other.m_composed.clear();
     }

--- a/include/internal/catch_test_case_tracker.hpp
+++ b/include/internal/catch_test_case_tracker.hpp
@@ -11,11 +11,10 @@
 #include "catch_compiler_capabilities.h"
 #include "catch_ptr.hpp"
 
-#include <map>
+#include <algorithm>
 #include <string>
 #include <assert.h>
 #include <vector>
-#include <iterator>
 #include <stdexcept>
 
 namespace Catch {
@@ -290,12 +289,12 @@ namespace TestCaseTracking {
             if( !filters.empty() ) {
                 m_filters.push_back(""); // Root - should never be consulted
                 m_filters.push_back(""); // Test Case - not a section filter
-                std::copy( filters.begin(), filters.end(), std::back_inserter( m_filters ) );
+                m_filters.insert( m_filters.end(), filters.begin(), filters.end() );
             }
         }
         void addNextFilters( std::vector<std::string> const& filters ) {
             if( filters.size() > 1 )
-                std::copy( filters.begin()+1, filters.end(), std::back_inserter( m_filters ) );
+                m_filters.insert( m_filters.end(), ++filters.begin(), filters.end() );
         }
     };
 


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, thats what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

This replaces 3 instances of
```c++
std::copy(first, last, std::back_inserter(dest_vec));
```
with
```
dest_vec.insert(dest_vec.end(), first, last);
```

It's not that I measured some difference in either compilation or run-time speed, I just prefer using a member function (which is almost guaranteed to run faster for more than 1 item) over `*inserter`. I also think having the modified thing on the left helps readability.

As for `#includes`, `<iterator>` provided the `back_inserter` so it's not needed anymore.
`catch_test_case_tracker.hpp` included `<map>` for no reason, so I removed that, and on the other hand didn't include `<algorithm>` while using `std::find_if`, so I added that.

