### PR TITLE
use inline 'libraryVersion()' function (closes #858)

### DIFF
--- a/include/catch_session.hpp
+++ b/include/catch_session.hpp
@@ -125,7 +125,7 @@ namespace Catch {
         }
 
         void showHelp( std::string const& processName ) {
-            Catch::cout() << "\nCatch v" << libraryVersion << "\n";
+            Catch::cout() << "\nCatch v" << libraryVersion() << "\n";
 
             m_cli.usage( Catch::cout(), processName );
             Catch::cout() << "For more detail usage please see the project docs\n" << std::endl;

--- a/include/internal/catch_version.h
+++ b/include/internal/catch_version.h
@@ -32,7 +32,7 @@ namespace Catch {
         void operator=( Version const& );
     };
 
-    extern Version libraryVersion;
+    inline Version libraryVersion();
 }
 
 #endif // TWOBLUECUBES_CATCH_VERSION_H_INCLUDED

--- a/include/internal/catch_version.hpp
+++ b/include/internal/catch_version.hpp
@@ -37,7 +37,10 @@ namespace Catch {
         return os;
     }
 
-    Version libraryVersion( 1, 8, 2, "", 0 );
+    inline Version libraryVersion() {
+        static Version version(1, 8, 2, "", 0);
+        return version;
+    }
 
 }
 

--- a/include/reporters/catch_reporter_console.hpp
+++ b/include/reporters/catch_reporter_console.hpp
@@ -254,7 +254,7 @@ namespace Catch {
             stream  << '\n' << getLineOfChars<'~'>() << '\n';
             Colour colour( Colour::SecondaryText );
             stream  << currentTestRunInfo->name
-                    << " is a Catch v"  << libraryVersion << " host application.\n"
+                    << " is a Catch v"  << libraryVersion() << " host application.\n"
                     << "Run with -? for options\n\n";
 
             if( m_config->rngSeed() != 0 )

--- a/scripts/releaseCommon.py
+++ b/scripts/releaseCommon.py
@@ -7,7 +7,7 @@ import string
 
 from scriptCommon import catchPath
 
-versionParser = re.compile( r'(\s*Version\slibraryVersion)\s*\(\s*(.*)\s*,\s*(.*)\s*,\s*(.*)\s*,\s*\"(.*)\"\s*,\s*(.*)\s*\).*' )
+versionParser = re.compile( r'(\s*static\sVersion\sversion)\s*\(\s*(.*)\s*,\s*(.*)\s*,\s*(.*)\s*,\s*\"(.*)\"\s*,\s*(.*)\s*\).*' )
 rootPath = os.path.join( catchPath, 'include/' )
 versionPath = os.path.join( rootPath, "internal/catch_version.hpp" )
 readmePath = os.path.join( catchPath, "README.md" )


### PR DESCRIPTION
## Description

This PR changes `libraryVersion` to be an inline function, rather than an extern struct. This resolves an issue where Catch could crash when a process exits if multiple libraries acting as a Catch 'main' are loaded, as this can lead to double-destruction of the Version struct on exit.

Let me know if this looks appropriate -- I also modified the release script parser to handle the new layout of how the version is declared.

Note that this would potentially break any users who were using the `libraryVersion` struct in their own code.