### PR TITLE
Add opt-in c++11 stream insertable check.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,13 +63,35 @@ This can be useful on certain platforms that do not provide ```std::cout``` and 
     CATCH_CONFIG_CPP11_UNIQUE_PTR              // Use std::unique_ptr instead of std::auto_ptr
     CATCH_CONFIG_CPP11_SHUFFLE                 // Use std::shuffle instead of std::random_shuffle
     CATCH_CONFIG_CPP11_TYPE_TRAITS             // Use std::enable_if and <type_traits>
-    CATCH_CONFIG_CPP11_STREAM_INSERTABLE_CHECK // Perform C++11 expression SFINAE based check if classes could be inserted to std::ostream
+    CATCH_CONFIG_CPP11_STREAM_INSERTABLE_CHECK // Use C++11 expression SFINAE to check if class can be inserted to std::ostream
 
 Catch has some basic compiler detection that will attempt to select the appropriate mix of these macros. However being incomplete - and often without access to the respective compilers - this detection tends to be conservative.
 So overriding control is given to the user. If a compiler supports a feature (and Catch does not already detect it) then one or more of these may be defined to enable it (or suppress it, in some cases). If you do do this please raise an issue, specifying your compiler version (ideally with an idea of how to detect it) and stating that it has such support.
 You may also suppress any of these features by using the `_NO_` form, e.g. `CATCH_CONFIG_CPP11_NO_NULLPTR`.
 
 All C++11 support can be disabled with `CATCH_CONFIG_NO_CPP11`
+
+## `CATCH_CONFIG_CPP11_STREAM_INSERTABLE_CHECK`
+
+This flag is off by default, but allows you to resolve problems caused by types with private base class that are streamable, but the classes themselves are not. Without it, the following code will cause a compilation error:
+```cpp
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+struct A {};
+std::ostream &operator<< (std::ostream &o, const A &v) { return o << 0; }
+
+struct B : private A {
+    bool operator==(int){ return true;}
+};
+
+B f ();
+std::ostream g ();
+
+TEST_CASE ("Error in streamable check") {
+    B x;
+    REQUIRE (x == 4);
+}
+```
 
 # Other toggles
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,17 +52,18 @@ This can be useful on certain platforms that do not provide ```std::cout``` and 
 
 # C++ conformance toggles
 
-	CATCH_CONFIG_CPP11_NULLPTR 				// nullptr is supported?
-	CATCH_CONFIG_CPP11_NOEXCEPT				// noexcept is supported?
-	CATCH_CONFIG_CPP11_GENERATED_METHODS	// delete and default keywords for methods
-	CATCH_CONFIG_CPP11_IS_ENUM				// std::is_enum is supported?
-	CATCH_CONFIG_CPP11_TUPLE				// std::tuple is supported
-	CATCH_CONFIG_VARIADIC_MACROS 			// Usually pre-C++11 compiler extensions are sufficient
-	CATCH_CONFIG_CPP11_LONG_LONG			// generates overloads for the long long type
-	CATCH_CONFIG_CPP11_OVERRIDE				// CATCH_OVERRIDE expands to override (for virtual function implementations)
-	CATCH_CONFIG_CPP11_UNIQUE_PTR			// Use std::unique_ptr instead of std::auto_ptr
-    CATCH_CONFIG_CPP11_SHUFFLE              // Use std::shuffle instead of std::random_shuffle
-    CATCH_CONFIG_CPP11_TYPE_TRAITS          // Use std::enable_if and <type_traits>
+    CATCH_CONFIG_CPP11_NULLPTR                 // nullptr is supported?
+    CATCH_CONFIG_CPP11_NOEXCEPT                // noexcept is supported?
+    CATCH_CONFIG_CPP11_GENERATED_METHODS       // delete and default keywords for methods
+    CATCH_CONFIG_CPP11_IS_ENUM                 // std::is_enum is supported?
+    CATCH_CONFIG_CPP11_TUPLE                   // std::tuple is supported
+    CATCH_CONFIG_VARIADIC_MACROS               // Usually pre-C++11 compiler extensions are sufficient
+    CATCH_CONFIG_CPP11_LONG_LONG               // generates overloads for the long long type
+    CATCH_CONFIG_CPP11_OVERRIDE                // CATCH_OVERRIDE expands to override (for virtual function implementations)
+    CATCH_CONFIG_CPP11_UNIQUE_PTR              // Use std::unique_ptr instead of std::auto_ptr
+    CATCH_CONFIG_CPP11_SHUFFLE                 // Use std::shuffle instead of std::random_shuffle
+    CATCH_CONFIG_CPP11_TYPE_TRAITS             // Use std::enable_if and <type_traits>
+    CATCH_CONFIG_CPP11_STREAM_INSERTABLE_CHECK // Perform C++11 expression SFINAE based check if classes could be inserted to std::ostream
 
 Catch has some basic compiler detection that will attempt to select the appropriate mix of these macros. However being incomplete - and often without access to the respective compilers - this detection tends to be conservative.
 So overriding control is given to the user. If a compiler supports a feature (and Catch does not already detect it) then one or more of these may be defined to enable it (or suppress it, in some cases). If you do do this please raise an issue, specifying your compiler version (ideally with an idea of how to detect it) and stating that it has such support.

--- a/include/internal/catch_tostring.h
+++ b/include/internal/catch_tostring.h
@@ -92,19 +92,18 @@ namespace Detail {
         enum { value = sizeof( testStreamable(s << t) ) == sizeof( TrueType ) };
     };
 #else
-  template<typename T>
-  class IsStreamInsertable
-  {
-      template<typename SS, typename TT>
-      static auto test(int)
-      -> decltype( std::declval<SS&>() << std::declval<TT>(), std::true_type() );
+    template<typename T>
+    class IsStreamInsertable {
+        template<typename SS, typename TT>
+        static auto test(int)
+        -> decltype( std::declval<SS&>() << std::declval<TT>(), std::true_type() );
 
-      template<typename, typename>
-      static auto test(...) -> std::false_type;
+        template<typename, typename>
+        static auto test(...) -> std::false_type;
 
-  public:
-      static const bool value = decltype(test<std::ostream,const T&>(0))::value;
-  };
+    public:
+        static const bool value = decltype(test<std::ostream,const T&>(0))::value;
+    };
 #endif
 
 #if defined(CATCH_CONFIG_CPP11_IS_ENUM)

--- a/include/internal/catch_tostring.h
+++ b/include/internal/catch_tostring.h
@@ -72,6 +72,7 @@ namespace Detail {
 
     extern const std::string unprintableString;
 
+ #if !defined(CATCH_CONFIG_CPP11_STREAM_INSERTABLE_CHECK)
     struct BorgType {
         template<typename T> BorgType( T const& );
     };
@@ -90,6 +91,21 @@ namespace Detail {
         static T  const&t;
         enum { value = sizeof( testStreamable(s << t) ) == sizeof( TrueType ) };
     };
+#else
+  template<typename T>
+  class IsStreamInsertable
+  {
+      template<typename SS, typename TT>
+      static auto test(int)
+      -> decltype( std::declval<SS&>() << std::declval<TT>(), std::true_type() );
+
+      template<typename, typename>
+      static auto test(...) -> std::false_type;
+
+  public:
+      static const bool value = decltype(test<std::ostream,const T&>(0))::value;
+  };
+#endif
 
 #if defined(CATCH_CONFIG_CPP11_IS_ENUM)
     template<typename T,

--- a/projects/SelfTest/CompilationTests.cpp
+++ b/projects/SelfTest/CompilationTests.cpp
@@ -51,3 +51,25 @@ TEST_CASE("#833") {
     REQUIRE(templated_tests<int>(3));
 }
 
+// Test containing example where original stream insertable check breaks compilation
+#if defined (CATCH_CONFIG_CPP11_STREAM_INSERTABLE_CHECK)
+namespace
+{
+  struct A {};
+  std::ostream &operator<< (std::ostream &o, const A &) { return o << 0;}
+
+  struct B : private A
+  {
+      bool operator==(int)const{ return true;}
+  };
+
+  B f ();
+  std::ostream g ();
+}
+
+TEST_CASE ("#872")
+{
+    B x;
+    REQUIRE (x == 4);
+}
+#endif

--- a/projects/SelfTest/CompilationTests.cpp
+++ b/projects/SelfTest/CompilationTests.cpp
@@ -53,22 +53,19 @@ TEST_CASE("#833") {
 
 // Test containing example where original stream insertable check breaks compilation
 #if defined (CATCH_CONFIG_CPP11_STREAM_INSERTABLE_CHECK)
-namespace
-{
-  struct A {};
-  std::ostream &operator<< (std::ostream &o, const A &) { return o << 0;}
+namespace {
+    struct A {};
+    std::ostream& operator<< (std::ostream &o, const A &) { return o << 0; }
 
-  struct B : private A
-  {
-      bool operator==(int)const{ return true;}
-  };
+    struct B : private A {
+        bool operator== (int) const { return true; }
+    };
 
-  B f ();
-  std::ostream g ();
+    B f ();
+    std::ostream g ();
 }
 
-TEST_CASE ("#872")
-{
+TEST_CASE( "#872" ) {
     B x;
     REQUIRE (x == 4);
 }


### PR DESCRIPTION
It adds opt-in define `CATCH_CONFIG_CPP_11_STREAM_INSERTABLE_CHECK` for enabling C++11 stream insertable check which should be better in some cases as suggested by @philsquared in #872.
All current tests seem to pass fine with it on my system.

Should I also add it to documentation somewhere?

PR should resolve #872 and #757 for those who opt-in.
