### PR TITLE
Add a note about when logging macros don't work

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -2,6 +2,8 @@
 
 Additional messages can be logged during a test case.
 
+Note that these macros do not log anything unless they are *directly* inside a catch test scope macro (i.e. TEST_CASE, SECTION, GIVEN/WHEN/THEN/...). In particular they cannot be used inside loops or ```if``` statements.
+
 ## Streaming macros
 
 All these macros allow heterogenous sequences of values to be streaming using the insertion operator (```<<```) in the same way that std::ostream, std::cout, etc support it.


### PR DESCRIPTION
## Description

The logging macros don't work quite the way I would expect when used inside if statements or loops. I think it's useful to have this documented.

## GitHub Issues

Related to  #415