### PR TITLE
cmake script to generate ctest definitions from catch tests

### DIFF
--- a/contrib/ParseAndAddCatchTests.cmake
+++ b/contrib/ParseAndAddCatchTests.cmake
@@ -56,7 +56,7 @@ function(ParseFile SourceFile TestTarget)
     RemoveComments(Contents)
 
     # Find definition of test names
-    string(REGEX MATCHALL "[ \t]*(CATCH_)?(TEST_CASE_METHOD|SCENARIO|TEST_CASE)[ \t]*\\([^\)]+\\)+[ \t]*{+[ \t]*(//[^\n]*[Tt][Ii][Mm][Ee][Oo][Uu][Tt][ \t]*[0-9]+)*" Tests "${Contents}")
+    string(REGEX MATCHALL "[ \t]*(CATCH_)?(TEST_CASE_METHOD|SCENARIO|TEST_CASE)[ \t]*\\([^\)]+\\)+[ \t\n]*{+[ \t]*(//[^\n]*[Tt][Ii][Mm][Ee][Oo][Uu][Tt][ \t]*[0-9]+)*" Tests "${Contents}")
 
     foreach(TestName ${Tests})
         # Strip newlines


### PR DESCRIPTION
#719

this is a cmake script which can be used for automatic CTest generating by parsing c++ sources for CATCH tests.
When you'd like to add CTest test you are usually doing this:

enable_testing()

add_test(...)
add_test(...)

Instead of the adding each test manually, I suggest to try using of this script which parses and adds found CATCH tests into cmake project

enable_testing()

include(ParseAndAddCatchTests)
ParseAndAddCatchTests(${PROJECT_NAME})

Notice 1: this script is a simplified version of Fraser999's scripts

Notice 2: this script doesn't replace and doesn't contain cmake commands for the adding CATCH lib into the project