### PR TITLE
Added warning if source file cannot be found

### DIFF
--- a/contrib/ParseAndAddCatchTests.cmake
+++ b/contrib/ParseAndAddCatchTests.cmake
@@ -48,6 +48,7 @@ endfunction()
 # Worker function
 function(ParseFile SourceFile TestTarget)
     if(NOT EXISTS ${SourceFile})
+        message(WARNING "Cannot find source file: ${SourceFile}")
         return()
     endif()
     file(STRINGS ${SourceFile} Contents NEWLINE_CONSUME)


### PR DESCRIPTION
If source files are defined using relative paths, CMake will compile the tests, but this script will (sometimes) fail to find and parse the tests from the source files.  I have added an explicit warning when ParseAndAddCatchTests fails to find a source file.

<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.
-->


## Description
ParseAndAddCatchTests will fail without warning when it cannot find source files to parse. There are instances where CMake will find sources to compile the executable, but ParseAndAddCatchTests fails to find those same source files when using relative paths. This can lead to confusion for the end user when CMake and make compile code without errors, yet running `make test` or `ctest` reports that there are no tests to run. An explicit warning allows users to resolve potential path problems.

## GitHub Issues
I decided to fix this problem myself instead of officially opening an issue.
