### PR TITLE
Added Win32 UNICODE wmain support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ elseif(USE_CPP14)
     set(CMAKE_CXX_FLAGS "-std=c++14 ${CMAKE_CXX_FLAGS}")
 endif()
 
-if($ENV{USE_WMAIN} STREQUAL "1")
+if(USE_WMAIN)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /ENTRY:wmainCRTStartup")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,10 @@ elseif(USE_CPP14)
     set(CMAKE_CXX_FLAGS "-std=c++14 ${CMAKE_CXX_FLAGS}")
 endif()
 
+if($ENV{USE_WMAIN} STREQUAL "1")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /ENTRY:wmainCRTStartup")
+endif()
+
 #checks that the given hard-coded list contains all headers + sources in the given folder
 function(CheckFileList LIST_VAR FOLDER)
   set(MESSAGE " should be added to the variable ${LIST_VAR}")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ environment:
     matrix:
         - additional_flags: "/permissive- /std:c++latest"
         - additional_flags: ""
+        - additional_flags: "/D _UNICODE /D UNICODE /ENTRY:wmainCRTStartup"
 
 matrix:
     exclude:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,13 +9,13 @@ os:
 environment:
     matrix:
         - additional_flags: "/permissive- /std:c++latest"
-          wmain: "0"
+          wmain: 0
 
         - additional_flags: ""
-          wmain: "0"
+          wmain: 0
 
         - additional_flags: "/D_UNICODE /DUNICODE"
-          wmain: "1"
+          wmain: 1
 
 matrix:
     exclude:
@@ -48,8 +48,7 @@ configuration:
 #Cmake will autodetect the compiler, but we set the arch
 before_build:
   - set CXXFLAGS=%additional_flags%
-  - set USE_WMAIN=%wmain%
-  - cmake -H. -BBuild -A%PLATFORM%
+  - cmake -H. -BBuild -A%PLATFORM% -DUSE_WMAIN=%wmain%
 
 # build with MSBuild
 build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,8 +9,13 @@ os:
 environment:
     matrix:
         - additional_flags: "/permissive- /std:c++latest"
+          additional_linker_flags: ""
+
         - additional_flags: ""
-        - additional_flags: "/D _UNICODE /D UNICODE /ENTRY:wmainCRTStartup"
+          additional_linker_flags: ""
+
+        - additional_flags: "/D_UNICODE /DUNICODE"
+          additional_linker_flags: "/ENTRY:wmainCRTStartup"
 
 matrix:
     exclude:
@@ -43,6 +48,7 @@ configuration:
 #Cmake will autodetect the compiler, but we set the arch
 before_build:
   - set CXXFLAGS=%additional_flags%
+  - set LDFLAGS=%additional_linker_flags"
   - cmake -H. -BBuild -A%PLATFORM%
 
 # build with MSBuild

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,13 +9,13 @@ os:
 environment:
     matrix:
         - additional_flags: "/permissive- /std:c++latest"
-          additional_linker_flags: ""
+          wmain: "0"
 
         - additional_flags: ""
-          additional_linker_flags: ""
+          wmain: "0"
 
         - additional_flags: "/D_UNICODE /DUNICODE"
-          additional_linker_flags: "/ENTRY:wmainCRTStartup"
+          wmain: "1"
 
 matrix:
     exclude:
@@ -48,7 +48,7 @@ configuration:
 #Cmake will autodetect the compiler, but we set the arch
 before_build:
   - set CXXFLAGS=%additional_flags%
-  - set LDFLAGS=%additional_linker_flags%
+  - set USE_WMAIN=%wmain%
   - cmake -H. -BBuild -A%PLATFORM%
 
 # build with MSBuild

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,7 @@ configuration:
 #Cmake will autodetect the compiler, but we set the arch
 before_build:
   - set CXXFLAGS=%additional_flags%
-  - set LDFLAGS=%additional_linker_flags"
+  - set LDFLAGS=%additional_linker_flags%
   - cmake -H. -BBuild -A%PLATFORM%
 
 # build with MSBuild

--- a/include/catch_session.hpp
+++ b/include/catch_session.hpp
@@ -166,6 +166,32 @@ namespace Catch {
             return returnCode;
         }
 
+#if defined(WIN32) && defined(UNICODE)
+        int run( int argc, wchar_t const* const* const argv ) {
+
+            char *utf8Argv[] = new char *[ argc ];
+
+            for ( int i = 0; i < argc; ++i ) {
+                int bufSize = WideCharToMultiByte( CP_UTF8, 0, argv[i], -1, NULL, 0, NULL, NULL );
+
+                utf8Argv[ i ] = new char[ bufSize ];
+
+                WideCharToMultiByte( CP_UTF8, 0, argv[i], -1, utf8Argv[i], bufSize, NULL, NULL );
+            }
+
+            int returnCode = applyCommandLine( argc, utf8Argv );
+            if( returnCode == 0 )
+                returnCode = run();
+
+            for ( int i = 0; i < argc; ++i )
+                delete [] utf8Argv[ i ];
+
+            delete [] utf8Argv;
+
+            return returnCode;
+        }
+#endif
+
         int run() {
             if( m_configData.showHelp )
                 return 0;

--- a/include/catch_session.hpp
+++ b/include/catch_session.hpp
@@ -166,10 +166,10 @@ namespace Catch {
             return returnCode;
         }
 
-#if defined(WIN32) && defined(UNICODE)
+    #if defined(WIN32) && defined(UNICODE)
         int run( int argc, wchar_t const* const* const argv ) {
 
-            char *utf8Argv[] = new char *[ argc ];
+            char **utf8Argv = new char *[ argc ];
 
             for ( int i = 0; i < argc; ++i ) {
                 int bufSize = WideCharToMultiByte( CP_UTF8, 0, argv[i], -1, NULL, 0, NULL, NULL );
@@ -190,7 +190,7 @@ namespace Catch {
 
             return returnCode;
         }
-#endif
+    #endif
 
         int run() {
             if( m_configData.showHelp )

--- a/include/internal/catch_default_main.hpp
+++ b/include/internal/catch_default_main.hpp
@@ -10,8 +10,14 @@
 
 #ifndef __OBJC__
 
+#if defined(WIN32) && defined(UNICODE)
+// Standard C/C++ Win32 Unicode wmain entry point
+extern "C" int wmain (int argc, wchar_t * argv[], wchar_t * []) {
+#else
 // Standard C/C++ main entry point
 int main (int argc, char * argv[]) {
+#endif
+
 	int result = Catch::Session().run( argc, argv );
     return ( result < 0xff ? result : 0xff );
 }

--- a/include/internal/catch_default_main.hpp
+++ b/include/internal/catch_default_main.hpp
@@ -10,7 +10,7 @@
 
 #ifndef __OBJC__
 
-#if defined(WIN32) && defined(UNICODE)
+#if defined(WIN32) && defined(_UNICODE) && !defined(DO_NOT_USE_WMAIN)
 // Standard C/C++ Win32 Unicode wmain entry point
 extern "C" int wmain (int argc, wchar_t * argv[], wchar_t * []) {
 #else


### PR DESCRIPTION
## Description
Added alternate main definition, available on Win32 platforms, when UNICODE
support is enabled. argv command line is a wchar_t, so Catch run interface should
be adapted in order to manage it.
