### PR TITLE
Improve junit xml for jenkins

### DIFF
--- a/include/reporters/catch_reporter_junit.hpp
+++ b/include/reporters/catch_reporter_junit.hpp
@@ -139,8 +139,7 @@ namespace Catch {
             std::string className = stats.testInfo.className;
 
             if( className.empty() ) {
-                if( rootSection.childSections.empty() )
-                    className = "global";
+                className = "global";
             }
             writeSection( className, "", rootSection );
         }

--- a/include/reporters/catch_reporter_junit.hpp
+++ b/include/reporters/catch_reporter_junit.hpp
@@ -150,6 +150,10 @@ namespace Catch {
                 if ( className.empty() )
                     className = "global";
             }
+
+            if ( !m_config->name().empty() )
+                className = m_config->name() + "." + className;
+
             writeSection( className, "", rootSection );
         }
 

--- a/include/reporters/catch_reporter_junit.hpp
+++ b/include/reporters/catch_reporter_junit.hpp
@@ -128,6 +128,13 @@ namespace Catch {
             xml.scopedElement( "system-err" ).writeText( trim( stdErrForSuite.str() ), false );
         }
 
+        static std::string fileNameTag( const std::set<std::string> &tags ) {
+            std::set<std::string>::const_iterator it = tags.lower_bound("#");
+            if( it != tags.end() && !it->empty() && it->front() == '#' )
+                return it->substr(1);
+            return std::string();
+        }
+
         void writeTestCase( TestCaseNode const& testCaseNode ) {
             TestCaseStats const& stats = testCaseNode.value;
 
@@ -139,7 +146,9 @@ namespace Catch {
             std::string className = stats.testInfo.className;
 
             if( className.empty() ) {
-                className = "global";
+                className = fileNameTag(stats.testInfo.tags);
+                if ( className.empty() )
+                    className = "global";
             }
             writeSection( className, "", rootSection );
         }


### PR DESCRIPTION
This pull request improves the junit xml output in the following ways

* The output isn't significantly different for TEST_CASEs with and without SECTIONs
* With "-#" test results will be grouped by [#filename] in jenkins test results UI
* The test suite name will be used for grouping too

Addressing these three issues ensures that the test results are logically organized in the jenkins test results UI.

This adresses #922 and maybe #320.

I've split the PR up in three tiny commits to ease review.