### PR TITLE
add --extra-info flag

### DIFF
--- a/include/internal/catch_commandline.hpp
+++ b/include/internal/catch_commandline.hpp
@@ -187,6 +187,10 @@ namespace Catch {
             .describe( "list all/matching test cases names only" )
             .bind( &ConfigData::listTestNamesOnly );
 
+        cli["--extra-info"]
+            .describe( "list more info" )
+            .bind( &ConfigData::extraInfo );
+
         cli["--list-reporters"]
             .describe( "list all reporters" )
             .bind( &ConfigData::listReporters );

--- a/include/internal/catch_commandline.hpp
+++ b/include/internal/catch_commandline.hpp
@@ -187,9 +187,9 @@ namespace Catch {
             .describe( "list all/matching test cases names only" )
             .bind( &ConfigData::listTestNamesOnly );
 
-        cli["--extra-info"]
-            .describe( "list more info" )
-            .bind( &ConfigData::extraInfo );
+        cli["--list-extra-info"]
+            .describe( "list all/matching test cases with more info" )
+            .bind( &ConfigData::listExtraInfo );
 
         cli["--list-reporters"]
             .describe( "list all reporters" )

--- a/include/internal/catch_config.hpp
+++ b/include/internal/catch_config.hpp
@@ -31,6 +31,7 @@ namespace Catch {
             listTags( false ),
             listReporters( false ),
             listTestNamesOnly( false ),
+            extraInfo( false ),
             showSuccessfulTests( false ),
             shouldDebugBreak( false ),
             noThrow( false ),
@@ -50,6 +51,7 @@ namespace Catch {
         bool listTags;
         bool listReporters;
         bool listTestNamesOnly;
+        bool extraInfo;
 
         bool showSuccessfulTests;
         bool shouldDebugBreak;
@@ -109,6 +111,7 @@ namespace Catch {
         bool listTestNamesOnly() const { return m_data.listTestNamesOnly; }
         bool listTags() const { return m_data.listTags; }
         bool listReporters() const { return m_data.listReporters; }
+        bool extraInfo() const { return m_data.extraInfo; }
 
         std::string getProcessName() const { return m_data.processName; }
 

--- a/include/internal/catch_config.hpp
+++ b/include/internal/catch_config.hpp
@@ -31,7 +31,7 @@ namespace Catch {
             listTags( false ),
             listReporters( false ),
             listTestNamesOnly( false ),
-            extraInfo( false ),
+            listExtraInfo( false ),
             showSuccessfulTests( false ),
             shouldDebugBreak( false ),
             noThrow( false ),
@@ -51,7 +51,7 @@ namespace Catch {
         bool listTags;
         bool listReporters;
         bool listTestNamesOnly;
-        bool extraInfo;
+        bool listExtraInfo;
 
         bool showSuccessfulTests;
         bool shouldDebugBreak;
@@ -111,7 +111,7 @@ namespace Catch {
         bool listTestNamesOnly() const { return m_data.listTestNamesOnly; }
         bool listTags() const { return m_data.listTags; }
         bool listReporters() const { return m_data.listReporters; }
-        bool extraInfo() const { return m_data.extraInfo; }
+        bool listExtraInfo() const { return m_data.listExtraInfo; }
 
         std::string getProcessName() const { return m_data.processName; }
 

--- a/include/internal/catch_list.hpp
+++ b/include/internal/catch_list.hpp
@@ -30,8 +30,9 @@ namespace Catch {
         }
 
         std::size_t matchedTests = 0;
-        TextAttributes nameAttr, tagsAttr;
+        TextAttributes nameAttr, descAttr, tagsAttr;
         nameAttr.setInitialIndent( 2 ).setIndent( 4 );
+        descAttr.setIndent( 4 );
         tagsAttr.setIndent( 6 );
 
         std::vector<TestCase> matchedTestCases = filterTests( getAllTestCasesSorted( config ), testSpec, config );
@@ -46,6 +47,13 @@ namespace Catch {
             Colour colourGuard( colour );
 
             Catch::cout() << Text( testCaseInfo.name, nameAttr ) << std::endl;
+            if( config.extraInfo() ) {
+                Catch::cout() << "    " << testCaseInfo.lineInfo << std::endl;
+                std::string description = testCaseInfo.description;
+                if( description == "" )
+                    description = "(NO DESCRIPTION)";
+                Catch::cout() << Text( description, descAttr ) << std::endl;
+            }
             if( !testCaseInfo.tags.empty() )
                 Catch::cout() << Text( testCaseInfo.tagsAsString, tagsAttr ) << std::endl;
         }
@@ -69,9 +77,12 @@ namespace Catch {
             matchedTests++;
             TestCaseInfo const& testCaseInfo = it->getTestCaseInfo();
             if( startsWith( testCaseInfo.name, '#' ) )
-               Catch::cout() << '"' << testCaseInfo.name << '"' << std::endl;
+               Catch::cout() << '"' << testCaseInfo.name << '"';
             else
-               Catch::cout() << testCaseInfo.name << std::endl;
+               Catch::cout() << testCaseInfo.name;
+            if ( config.extraInfo() )
+                Catch::cout() << "\t@" << testCaseInfo.lineInfo;
+            Catch::cout() << std::endl;
         }
         return matchedTests;
     }

--- a/include/internal/catch_list.hpp
+++ b/include/internal/catch_list.hpp
@@ -174,7 +174,7 @@ namespace Catch {
 
     inline Option<std::size_t> list( Config const& config ) {
         Option<std::size_t> listedCount;
-        if( config.listTests() || config.listExtraInfo() )
+        if( config.listTests() || ( config.listExtraInfo() && !config.listTestNamesOnly() ) )
             listedCount = listedCount.valueOr(0) + listTests( config );
         if( config.listTestNamesOnly() )
             listedCount = listedCount.valueOr(0) + listTestsNamesOnly( config );

--- a/include/internal/catch_list.hpp
+++ b/include/internal/catch_list.hpp
@@ -47,10 +47,10 @@ namespace Catch {
             Colour colourGuard( colour );
 
             Catch::cout() << Text( testCaseInfo.name, nameAttr ) << std::endl;
-            if( config.extraInfo() ) {
+            if( config.listExtraInfo() ) {
                 Catch::cout() << "    " << testCaseInfo.lineInfo << std::endl;
                 std::string description = testCaseInfo.description;
-                if( description == "" )
+                if( description.empty() )
                     description = "(NO DESCRIPTION)";
                 Catch::cout() << Text( description, descAttr ) << std::endl;
             }
@@ -80,7 +80,7 @@ namespace Catch {
                Catch::cout() << '"' << testCaseInfo.name << '"';
             else
                Catch::cout() << testCaseInfo.name;
-            if ( config.extraInfo() )
+            if ( config.listExtraInfo() )
                 Catch::cout() << "\t@" << testCaseInfo.lineInfo;
             Catch::cout() << std::endl;
         }
@@ -174,7 +174,7 @@ namespace Catch {
 
     inline Option<std::size_t> list( Config const& config ) {
         Option<std::size_t> listedCount;
-        if( config.listTests() )
+        if( config.listTests() || config.listExtraInfo() )
             listedCount = listedCount.valueOr(0) + listTests( config );
         if( config.listTestNamesOnly() )
             listedCount = listedCount.valueOr(0) + listTestsNamesOnly( config );


### PR DESCRIPTION
this will add line info to test lists, and test descriptions to the long
form of the test list

Related to issue #930 