### PR TITLE
Fix for JUnit reporter when using dynamically generated sections

### DIFF
--- a/include/reporters/catch_reporter_bases.hpp
+++ b/include/reporters/catch_reporter_bases.hpp
@@ -137,7 +137,8 @@ namespace Catch {
             BySectionInfo( SectionInfo const& other ) : m_other( other ) {}
             BySectionInfo( BySectionInfo const& other ) : m_other( other.m_other ) {}
             bool operator() ( Ptr<SectionNode> const& node ) const {
-                return node->stats.sectionInfo.lineInfo == m_other.lineInfo;
+                return ((node->stats.sectionInfo.name == m_other.name) &&
+                        (node->stats.sectionInfo.lineInfo == m_other.lineInfo));
             }
         private:
             void operator=( BySectionInfo const& );

--- a/single_include/catch.hpp
+++ b/single_include/catch.hpp
@@ -9597,8 +9597,7 @@ namespace Catch {
             BySectionInfo( SectionInfo const& other ) : m_other( other ) {}
             BySectionInfo( BySectionInfo const& other ) : m_other( other.m_other ) {}
             bool operator() ( Ptr<SectionNode> const& node ) const {
-                return ((node->stats.sectionInfo.name == m_other.name) &&
-                        (node->stats.sectionInfo.lineInfo == m_other.lineInfo));
+                return node->stats.sectionInfo.lineInfo == m_other.lineInfo;
             }
         private:
             void operator=( BySectionInfo const& );

--- a/single_include/catch.hpp
+++ b/single_include/catch.hpp
@@ -9597,7 +9597,8 @@ namespace Catch {
             BySectionInfo( SectionInfo const& other ) : m_other( other ) {}
             BySectionInfo( BySectionInfo const& other ) : m_other( other.m_other ) {}
             bool operator() ( Ptr<SectionNode> const& node ) const {
-                return node->stats.sectionInfo.lineInfo == m_other.lineInfo;
+                return ((node->stats.sectionInfo.name == m_other.name) &&
+                        (node->stats.sectionInfo.lineInfo == m_other.lineInfo));
             }
         private:
             void operator=( BySectionInfo const& );


### PR DESCRIPTION
## Description
As reported in #961 dynamically generated sections are not correctly reported when using JUnit reporter. The cause of this is that only the source code line is taken into account when comparing sections in `CumulativeReporterBase` when it should also consider the section's name.

## GitHub Issues
Closes #961
