### PR TITLE
Explicit Ctor fixed

### DIFF
--- a/include/reporters/catch_reporter_multi.cpp
+++ b/include/reporters/catch_reporter_multi.cpp
@@ -7,7 +7,7 @@
  */
 
  #include "catch_reporter_multi.h"
- 
+
 namespace Catch {
 
     void MultipleReporters::add( IStreamingReporterPtr&& reporter ) {
@@ -19,10 +19,10 @@ namespace Catch {
     }
 
     std::set<Verbosity> MultipleReporters::getSupportedVerbosities() {
-        return { };
+        return std::set<Verbosity>{ };
     }
 
-    
+
     void MultipleReporters::noMatchingTestCases( std::string const& spec ) {
         for( auto const& reporter : m_reporters )
             reporter->noMatchingTestCases( spec );


### PR DESCRIPTION
This is a fixes the build failure caused by an explicit ctor not being called explicit. The failure occurres only under some circumstances as described in #1013.


I accidentally fixed two whitespaces too.


## GitHub Issues

**Ref.** #1013 

