### PR TITLE
`RandomNumberGenerator::result_type` should be unsigned

### DIFF
--- a/include/internal/catch_test_case_registry_impl.hpp
+++ b/include/internal/catch_test_case_registry_impl.hpp
@@ -22,7 +22,7 @@
 namespace Catch {
 
     struct RandomNumberGenerator {
-        typedef std::ptrdiff_t result_type;
+        typedef std::make_unsigned<std::ptrdiff_t>::type result_type;
 
         result_type operator()( result_type n ) const { return std::rand() % n; }
 

--- a/include/internal/catch_test_case_registry_impl.hpp
+++ b/include/internal/catch_test_case_registry_impl.hpp
@@ -22,7 +22,7 @@
 namespace Catch {
 
     struct RandomNumberGenerator {
-        typedef std::make_unsigned<std::ptrdiff_t>::type result_type;
+        typedef std::uint32_t result_type;
 
         result_type operator()( result_type n ) const { return std::rand() % n; }
 

--- a/include/internal/catch_test_case_registry_impl.hpp
+++ b/include/internal/catch_test_case_registry_impl.hpp
@@ -22,7 +22,7 @@
 namespace Catch {
 
     struct RandomNumberGenerator {
-        typedef std::uint32_t result_type;
+        typedef unsigned int result_type;
 
         result_type operator()( result_type n ) const { return std::rand() % n; }
 


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
`result_type` must be unsigned:
http://en.cppreference.com/w/cpp/concept/UniformRandomBitGenerator

Using a signed type causes an infinite loop working with MS Visual Studio 2017, targetting: v140, WindowsTargetPlatformVersion 10.0.15063.0, Debug, x64

Simply using uint32_t seems sufficient, since the value of `max()` is small enough.

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
