### PR TITLE
adds flushes to the output stream of teamcity reporter,…

### DIFF
--- a/include/reporters/catch_reporter_teamcity.hpp
+++ b/include/reporters/catch_reporter_teamcity.hpp
@@ -141,6 +141,7 @@ namespace Catch {
                            << "]\n";
                 }
             }
+            stream.flush();
             return true;
         }
 
@@ -154,6 +155,7 @@ namespace Catch {
             StreamingReporterBase::testCaseStarting( testInfo );
             stream << "##teamcity[testStarted name='"
                 << escape( testInfo.name ) << "']\n";
+            stream.flush();
         }
 
         virtual void testCaseEnded( TestCaseStats const& testCaseStats ) CATCH_OVERRIDE {
@@ -169,6 +171,7 @@ namespace Catch {
             stream << "##teamcity[testFinished name='"
                     << escape( testCaseStats.testInfo.name ) << "' duration='"
                     << m_testTimer.getElapsedMilliseconds() << "']\n";
+            stream.flush();
         }
 
     private:


### PR DESCRIPTION
… making the test output more responsive.

## Description
There is the issue with the teamcity reporter described here:
https://github.com/philsquared/Catch/blob/master/docs/build-systems.md#teamcity-reporter
Tests are only reported after the whole suite is completed.
This can be fixed by explicitly flushing the output stream of the reporter.

I added flush commands to the output functions of the reporter.

Now (long) running tests are reported in Teamcity more quickly, almost as soon as the tests are completed.

If these flushes would create a performance issue, additional code could be added to only flush every some seconds. But in my setup it did not seem necessary.
